### PR TITLE
fix(deps): pin System.Security.Cryptography.Xml to patched 10.0.10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,11 @@
   -->
   <ItemGroup>
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <!-- Security pin: 10.0.0-10.0.9 have known high-severity vulnerabilities; 10.0.10 is the first
+         patched release. Applied via a direct PackageReference in MonacoEditorTestApp: this repo does
+         not set CentralPackageTransitivePinningEnabled, so CPM does not pin transitive versions on its
+         own and a direct reference is needed for the pin to take effect. -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="StreamJsonRpc" Version="2.25.28" />
     <PackageVersion Include="Uno.CommunityToolkit.WinUI" Version="7.1.204" />
     <PackageVersion Include="Uno.WinUI" Version="6.5.153" />

--- a/MonacoEditorTestApp/MonacoEditorTestApp.csproj
+++ b/MonacoEditorTestApp/MonacoEditorTestApp.csproj
@@ -48,6 +48,18 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<!--
+			Direct reference to force the patched System.Security.Cryptography.Xml (version from
+			Directory.Packages.props) into the app graph. Version 10.0.9 flows in transitively and has
+			known high-severity vulnerabilities that fail the NU1903 audit (GHSA-23rf-6693-g89p and
+			related). With CentralPackageTransitivePinningEnabled unset (as it is in this repo), CPM
+			does not pin transitive dependency versions on its own, so this direct reference is what
+			applies the fix. Enabling that option would be the alternative to referencing it directly.
+		-->
+		<PackageReference Include="System.Security.Cryptography.Xml" />
+	</ItemGroup>
+
+	<ItemGroup>
 	  <Folder Include="bin\Debug\" />
 	  <Folder Include="Platforms/Desktop/" />
 	</ItemGroup>


### PR DESCRIPTION
## Problem

CI on `main` fails at the **Build WASM test app** step (both the Ubuntu **Build** and **Build (macOS ARM)** jobs) with `NU1903`, promoted to an error by NuGetAudit:

```
error NU1903: Warning As Error: Package 'System.Security.Cryptography.Xml' 10.0.9
  has a known high severity vulnerability
```

(Four advisories: GHSA-23rf-6693-g89p, GHSA-8q5v-6pqq-x66h, GHSA-cvvh-rhrc-wg4q, GHSA-g8r8-53c2-pm3f.)

The other red jobs are cascades, not independent failures — **Desktop Tests (Windows)** is skipped because it depends on Build, and **Coverage Report** fails only because no coverage artifacts were produced (tests never ran).

## Root cause

A prior commit added `<PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />` to `Directory.Packages.props`, but that fix was ineffective for two reasons:

1. **10.0.9 is itself the vulnerable version** — the advisories cover 10.0.0–10.0.9; the first patched release is **10.0.10**.
2. **The pin never applied.** Central Package Management is enabled (`ManagePackageVersionsCentrally=true`) but `CentralPackageTransitivePinningEnabled` is not set. A bare `<PackageVersion>` with no matching `<PackageReference>` does **not** override a transitive dependency, so the vulnerable transitive `10.0.9` flowed through unchanged.

## Fix

- Bump the CPM pin `10.0.9 → 10.0.10` (first patched release) in `Directory.Packages.props`.
- Add a direct `<PackageReference Include="System.Security.Cryptography.Xml" />` (version from CPM) in `MonacoEditorTestApp.csproj`, so the pin actually enters the app graph and overrides the transitive version. Both edits carry a comment explaining the reason.

Scope is limited to the test app: the library build already passes audit (including its own `browserwasm` TFM), so the vulnerable package enters only through the app-level packaging graph.

## Verification

Ran the exact CI build steps locally:

```
dotnet build MonacoEditorTestApp/MonacoEditorTestApp.csproj -f net10.0-browserwasm   # 0 warnings, 0 errors
dotnet build MonacoEditorTestApp/MonacoEditorTestApp.csproj -f net10.0-desktop        # 0 warnings, 0 errors
```

Both TFMs build clean and the package resolves to `10.0.10` (confirmed in `project.assets.json`). The `desktop` TFM matters because CI never reached it — WASM failed first — so this confirms no build error was masked behind the audit gate.

## Reference

- https://github.com/unoplatform/uno/issues/23829
- Failing CI run: https://github.com/unoplatform/uno.monaco.editor/actions/runs/29861684566

🤖 Generated with [Claude Code](https://claude.com/claude-code)
