### PR TITLE
fix(ci): unblock Desktop CDP tests on windows-latest (WebView2 v150 regression)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,29 @@ jobs:
         with:
           playwright-version: ${{ env.PLAYWRIGHT_VERSION }}
 
+      # WebView2 runtime v150 disabled the CDP remote-debugging endpoint for hosts running
+      # at High Integrity Level (WebView2Feedback #5640). GitHub windows-latest runs steps
+      # elevated, so the runner's Evergreen runtime (150.x) yields no CDP listener. Pin a
+      # pre-regression Fixed Version runtime (149.0.4022.98, #5640's last-working build,
+      # distributed as a stable NuGet package) and point WebView2 at it via
+      # WEBVIEW2_BROWSER_EXECUTABLE_FOLDER so DesktopCDP tests can attach.
+      - name: Pin WebView2 Fixed Version runtime 149 (CDP workaround, WebView2Feedback #5640)
+        shell: pwsh
+        run: |
+          $version = '149.0.4022.98'
+          $zip = Join-Path $env:RUNNER_TEMP 'wv2-fv.zip'
+          $dest = Join-Path $env:RUNNER_TEMP 'wv2-fv'
+          $url = "https://api.nuget.org/v3-flatcontainer/webview2.runtime.x64/$version/webview2.runtime.x64.$version.nupkg"
+          Write-Host "Downloading WebView2 Fixed Version runtime $version"
+          $ProgressPreference = 'SilentlyContinue'  # IWR progress stream cripples large downloads
+          Invoke-WebRequest -Uri $url -OutFile $zip
+          Expand-Archive -Path $zip -DestinationPath $dest -Force
+          $exe = Get-ChildItem -Path $dest -Recurse -Filter 'msedgewebview2.exe' | Select-Object -First 1
+          if (-not $exe) { throw "msedgewebview2.exe not found under $dest" }
+          $folder = $exe.Directory.FullName
+          Write-Host "WEBVIEW2_BROWSER_EXECUTABLE_FOLDER=$folder"
+          "WEBVIEW2_BROWSER_EXECUTABLE_FOLDER=$folder" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
       # Windows runners have WebView2 Runtime + Edge pre-installed and support CDP.
       # DesktopCDP tests are enabled here; WASM Playwright tests are covered by Ubuntu.
       - name: Run tests (unit + DesktopCDP)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,10 +165,10 @@ jobs:
 
       # Windows runners have WebView2 Runtime + Edge pre-installed and support CDP.
       # DesktopCDP tests are enabled here; WASM Playwright tests are covered by Ubuntu.
-      # Note: the runner executes elevated (High Integrity Level), so the fixture publishes
-      # --remote-debugging-port via the HKLM WebView2 policy rather than the WEBVIEW2_*
-      # environment variable, which WebView2 v150 drops under elevation (WebView2Feedback
-      # #5640). See DesktopAppFixture.PublishHklmBrowserArgumentsAsync.
+      # Note: the fixture always sets --remote-debugging-port via the WEBVIEW2_* env var, and
+      # because this runner executes elevated (High Integrity Level) -- where WebView2 v150
+      # drops that env var (WebView2Feedback #5640) -- it additionally publishes the switch
+      # through the HKLM WebView2 policy. See DesktopAppFixture.PublishHklmBrowserArgumentsAsync.
       - name: Run tests (unit + DesktopCDP)
         run: dotnet test --project MonacoEditorComponent.Tests/MonacoEditorComponent.Tests.csproj -c Release -p:ArtifactsPath="${{ env.ARTIFACTS_PATH }}" --no-build --coverage --coverage-output-format cobertura --results-directory ${{ runner.temp }}/TestResults -- --filter-not-trait "Category=WasmPlaywright" --report-xunit --report-xunit-filename desktop-test-results.xml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,31 +163,12 @@ jobs:
         with:
           playwright-version: ${{ env.PLAYWRIGHT_VERSION }}
 
-      # WebView2 runtime v150 disabled the CDP remote-debugging endpoint for hosts running
-      # at High Integrity Level (WebView2Feedback #5640). GitHub windows-latest runs steps
-      # elevated, so the runner's Evergreen runtime (150.x) yields no CDP listener. Pin a
-      # pre-regression Fixed Version runtime (149.0.4022.98, #5640's last-working build,
-      # distributed as a stable NuGet package) and point WebView2 at it via
-      # WEBVIEW2_BROWSER_EXECUTABLE_FOLDER so DesktopCDP tests can attach.
-      - name: Pin WebView2 Fixed Version runtime 149 (CDP workaround, WebView2Feedback #5640)
-        shell: pwsh
-        run: |
-          $version = '149.0.4022.98'
-          $zip = Join-Path $env:RUNNER_TEMP 'wv2-fv.zip'
-          $dest = Join-Path $env:RUNNER_TEMP 'wv2-fv'
-          $url = "https://api.nuget.org/v3-flatcontainer/webview2.runtime.x64/$version/webview2.runtime.x64.$version.nupkg"
-          Write-Host "Downloading WebView2 Fixed Version runtime $version"
-          $ProgressPreference = 'SilentlyContinue'  # IWR progress stream cripples large downloads
-          Invoke-WebRequest -Uri $url -OutFile $zip
-          Expand-Archive -Path $zip -DestinationPath $dest -Force
-          $exe = Get-ChildItem -Path $dest -Recurse -Filter 'msedgewebview2.exe' | Select-Object -First 1
-          if (-not $exe) { throw "msedgewebview2.exe not found under $dest" }
-          $folder = $exe.Directory.FullName
-          Write-Host "WEBVIEW2_BROWSER_EXECUTABLE_FOLDER=$folder"
-          "WEBVIEW2_BROWSER_EXECUTABLE_FOLDER=$folder" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-
       # Windows runners have WebView2 Runtime + Edge pre-installed and support CDP.
       # DesktopCDP tests are enabled here; WASM Playwright tests are covered by Ubuntu.
+      # Note: the runner executes elevated (High Integrity Level), so the fixture publishes
+      # --remote-debugging-port via the HKLM WebView2 policy rather than the WEBVIEW2_*
+      # environment variable, which WebView2 v150 drops under elevation (WebView2Feedback
+      # #5640). See DesktopAppFixture.PublishHklmBrowserArgumentsAsync.
       - name: Run tests (unit + DesktopCDP)
         run: dotnet test --project MonacoEditorComponent.Tests/MonacoEditorComponent.Tests.csproj -c Release -p:ArtifactsPath="${{ env.ARTIFACTS_PATH }}" --no-build --coverage --coverage-output-format cobertura --results-directory ${{ runner.temp }}/TestResults -- --filter-not-trait "Category=WasmPlaywright" --report-xunit --report-xunit-filename desktop-test-results.xml
 

--- a/MonacoEditorComponent.Tests/DesktopAppFixture.cs
+++ b/MonacoEditorComponent.Tests/DesktopAppFixture.cs
@@ -19,7 +19,7 @@ namespace MonacoEditorComponent.Tests;
 /// macOS (WKWebView) and Linux (WebKitGTK) are not Chromium and do not support CDP.</para>
 ///
 /// <para><b>Deterministic readiness</b>: The fixture does NOT rely on arbitrary delays.
-/// It polls <c>http://localhost:{port}/json/version</c> to confirm CDP is ready,
+/// It polls <c>http://127.0.0.1:{port}/json/version</c> to confirm CDP is ready,
 /// then waits for the Monaco editor page via Playwright page enumeration.</para>
 ///
 /// <para><b>Agent-driven testing pattern (Playwright MCP)</b>:
@@ -107,7 +107,14 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         _ = CaptureProcessOutputAsync(_appProcess, _processLogPath, _logCaptureCts.Token);
 
         // 5. Deterministic readiness: poll CDP version endpoint.
-        var cdpEndpoint = $"http://localhost:{_cdpPort}";
+        // Use the IPv4 loopback literal, not "localhost": WebView2/Chromium's
+        // --remote-debugging-port (with no --remote-debugging-address) binds to
+        // 127.0.0.1 only. On runners where "localhost" resolves to IPv6 (::1) first,
+        // the CDP endpoint is unreachable (connection refused) and readiness polling
+        // times out even though the app itself started fine. This also matches the
+        // port reserved via IPAddress.Loopback in GetAvailablePort(). The endpoint
+        // feeds both the readiness poll below and ConnectOverCDPAsync in step 6.
+        var cdpEndpoint = $"http://127.0.0.1:{_cdpPort}";
         await WaitForCdpReady(cdpEndpoint);
 
         // 6. Connect Playwright via CDP.
@@ -343,10 +350,9 @@ public sealed class DesktopAppFixture : IAsyncLifetime
             if (_appProcess is { HasExited: true })
             {
                 var exitCode = _appProcess.ExitCode;
-                var logContent = File.Exists(_processLogPath) ? File.ReadAllText(_processLogPath) : "(no log)";
                 throw new InvalidOperationException(
                     $"MonacoEditorTestApp process exited unexpectedly with code {exitCode} before CDP was ready.\n" +
-                    $"Process log:\n{logContent}");
+                    $"Process log:\n{CaptureLogSnapshot()}");
             }
 
             try
@@ -369,10 +375,22 @@ public sealed class DesktopAppFixture : IAsyncLifetime
             await Task.Delay(CdpPollIntervalMs);
         }
 
-        var logOnTimeout = File.Exists(_processLogPath) ? File.ReadAllText(_processLogPath) : "(no log)";
         throw new TimeoutException(
             $"CDP endpoint at {versionUrl} did not become ready within {CdpReadyTimeoutMs}ms.\n" +
-            $"Process log:\n{logOnTimeout}");
+            $"Process log:\n{CaptureLogSnapshot()}");
+    }
+
+    /// <summary>
+    /// Returns the captured process stdout/stderr as a single string from the in-memory
+    /// buffer. Reading the on-disk log file directly is unsafe on Windows: the background
+    /// <see cref="CaptureProcessOutputAsync"/> writer holds it open, and a concurrent
+    /// reader's implicit FileShare.Read does not grant the writer's Write access, which
+    /// surfaces as an IOException that masks the real readiness diagnostic.
+    /// </summary>
+    private string CaptureLogSnapshot()
+    {
+        var lines = GetLinesAfter(0);
+        return lines.Count > 0 ? string.Join(Environment.NewLine, lines) : "(no log)";
     }
 
     private async Task<IPage> FindMonacoPage()

--- a/MonacoEditorComponent.Tests/DesktopAppFixture.cs
+++ b/MonacoEditorComponent.Tests/DesktopAppFixture.cs
@@ -48,6 +48,11 @@ public sealed class DesktopAppFixture : IAsyncLifetime
     private string _processLogPath = string.Empty;
     private int _cdpPort;
     private CancellationTokenSource? _logCaptureCts;
+    private bool _wroteHklmBrowserArgs;
+
+    // Machine-wide WebView2 policy key. Arguments published here survive an elevated host
+    // process, unlike the WEBVIEW2_* environment variables (WebView2Feedback #5640).
+    private const string WebView2PolicyKey = @"HKLM\SOFTWARE\Policies\Microsoft\Edge\WebView2";
 
     // In-memory log lines for cursor-based query API.
     private readonly List<string> _logLines = [];
@@ -101,16 +106,17 @@ public sealed class DesktopAppFixture : IAsyncLifetime
             },
         };
 
-        // WebView2 runtime v150 disables the CDP loopback endpoint when the host runs at
-        // High Integrity Level (elevated), which is how the windows-latest CI runner
-        // executes -- so --remote-debugging-port silently produces no listener there
-        // (WebView2Feedback #5640). When CI provides a pre-v150 Fixed Version runtime via
-        // WEBVIEW2_BROWSER_EXECUTABLE_FOLDER, forward it so the app uses that runtime and
-        // CDP works again. Unset locally (developers run non-elevated) => Evergreen runtime.
-        var fixedRuntimeFolder = Environment.GetEnvironmentVariable("WEBVIEW2_BROWSER_EXECUTABLE_FOLDER");
-        if (!string.IsNullOrEmpty(fixedRuntimeFolder))
+        // WebView2 runtime v150 hardened elevated (High Integrity Level) hosts: switches
+        // supplied through user-writable channels (WEBVIEW2_* env vars, HKCU policy) are
+        // ignored -- only HKLM policy and API args are honored (WebView2Feedback #5640,
+        // "by design"). The windows-latest CI runner executes elevated, so the
+        // --remote-debugging-port set above via WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS is
+        // silently dropped and no CDP listener starts. When elevated, additionally publish
+        // the switch through the HKLM AdditionalBrowserArguments policy, which survives
+        // elevation. Non-elevated (local dev) keeps using the env var and leaves HKLM alone.
+        if (OperatingSystem.IsWindows() && Environment.IsPrivilegedProcess)
         {
-            startInfo.Environment["WEBVIEW2_BROWSER_EXECUTABLE_FOLDER"] = fixedRuntimeFolder;
+            await PublishHklmBrowserArgumentsAsync($"--remote-debugging-port={_cdpPort}");
         }
 
         _appProcess = Process.Start(startInfo)
@@ -198,6 +204,17 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         if (!string.IsNullOrEmpty(_userDataFolder) && Directory.Exists(_userDataFolder))
         {
             try { Directory.Delete(_userDataFolder, recursive: true); } catch { /* best-effort */ }
+        }
+
+        // Revert the machine-wide WebView2 policy set for elevated CDP (WebView2Feedback #5640).
+        if (_wroteHklmBrowserArgs)
+        {
+            try
+            {
+                await RunCaptureAsync("reg", $@"delete ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments /f");
+            }
+            catch { /* best-effort */ }
+            _wroteHklmBrowserArgs = false;
         }
     }
 
@@ -375,10 +392,8 @@ public sealed class DesktopAppFixture : IAsyncLifetime
                 if (response.IsSuccessStatusCode)
                 {
                     // Record the runtime that actually answered CDP (the "Browser" field,
-                    // e.g. "Edg/149.0.4022.98"). This is authoritative for which WebView2
-                    // runtime loaded: the machine's Evergreen version in the registry is
-                    // not, once a Fixed Version runtime is pinned via
-                    // WEBVIEW2_BROWSER_EXECUTABLE_FOLDER (WebView2Feedback #5640).
+                    // e.g. "Edg/150.0.4078.65") to test-artifacts. Useful confirmation of
+                    // exactly which WebView2 runtime served the session.
                     try
                     {
                         var versionBody = await response.Content.ReadAsStringAsync();
@@ -388,7 +403,8 @@ public sealed class DesktopAppFixture : IAsyncLifetime
                             await File.WriteAllTextAsync(Path.Join(dir, "cdp-version.txt"), versionBody);
                         }
                     }
-                    catch { /* best-effort */ }
+                    catch (IOException) { /* best-effort */ }
+                    catch (UnauthorizedAccessException) { /* best-effort */ }
                     return; // CDP is ready.
                 }
             }
@@ -561,6 +577,30 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         try { return await readTask; }
         catch (OperationCanceledException) { return string.Empty; }
         catch (IOException) { return string.Empty; }
+    }
+
+    /// <summary>
+    /// Publishes WebView2 browser arguments through the machine-wide (HKLM) policy so they
+    /// survive an elevated host process. WebView2 v150 ignores the user-writable channels
+    /// (WEBVIEW2_* environment variables, HKCU policy) when the host runs at High Integrity
+    /// Level -- only HKLM policy and API args are honored (WebView2Feedback #5640). Called
+    /// only when elevated (the sole case that needs it); best-effort and reverted in
+    /// <see cref="DisposeAsync"/>. A pre-existing machine policy value is left untouched.
+    /// </summary>
+    private async Task PublishHklmBrowserArgumentsAsync(string arguments)
+    {
+        // Do not clobber a value the machine already defines (the CI runner defines none).
+        var existing = await RunCaptureAsync("reg", $@"query ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments");
+        if (existing.Contains("AdditionalBrowserArguments", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        // Set the flag before writing so DisposeAsync reverts the machine policy even if the
+        // add result cannot be parsed; deleting an absent value is a harmless no-op.
+        _wroteHklmBrowserArgs = true;
+        await RunCaptureAsync("reg",
+            $@"add ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments /t REG_SZ /d ""{arguments}"" /f");
     }
 
     /// <summary>

--- a/MonacoEditorComponent.Tests/DesktopAppFixture.cs
+++ b/MonacoEditorComponent.Tests/DesktopAppFixture.cs
@@ -405,10 +405,10 @@ public sealed class DesktopAppFixture : IAsyncLifetime
                     try
                     {
                         var versionBody = await response.Content.ReadAsStringAsync();
-                        var dir = Path.GetDirectoryName(_processLogPath);
-                        if (!string.IsNullOrEmpty(dir))
+                        var versionPath = ArtifactSiblingPath("cdp-version.txt");
+                        if (versionPath is not null)
                         {
-                            await File.WriteAllTextAsync(Path.Join(dir, "cdp-version.txt"), versionBody);
+                            await File.WriteAllTextAsync(versionPath, versionBody);
                         }
                     }
                     catch (IOException) { /* best-effort */ }
@@ -447,7 +447,7 @@ public sealed class DesktopAppFixture : IAsyncLifetime
     /// <c>WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS</c> flag was not honored).</description></item>
     /// <item><description>Edge <c>RemoteDebuggingAllowed</c> policy = 0 disables CDP entirely.</description></item>
     /// </list>
-    /// Also written to <c>test-artifacts/cdp-diagnostics.txt</c> for the uploaded artifact.
+    /// Also written to <c>test-artifacts/{run}-cdp-diagnostics.txt</c> for the uploaded artifact.
     /// </summary>
     private async Task<string> CollectCdpDiagnosticsAsync()
     {
@@ -528,10 +528,10 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         // Persist to the uploaded artifacts directory for reliable capture.
         try
         {
-            var dir = Path.GetDirectoryName(_processLogPath);
-            if (!string.IsNullOrEmpty(dir))
+            var diagnosticsPath = ArtifactSiblingPath("cdp-diagnostics.txt");
+            if (diagnosticsPath is not null)
             {
-                await File.WriteAllTextAsync(Path.Join(dir, "cdp-diagnostics.txt"), diagnostics);
+                await File.WriteAllTextAsync(diagnosticsPath, diagnostics);
             }
         }
         catch (IOException) { /* best-effort */ }
@@ -596,6 +596,22 @@ public sealed class DesktopAppFixture : IAsyncLifetime
     }
 
     /// <summary>
+    /// Builds an artifact path sharing the timestamped base name of the process log
+    /// (e.g. <c>desktop-fixture-{timestamp}-cdp-version.txt</c>) so a run's diagnostics group
+    /// together and don't overwrite each other across parallel fixture instances or retries.
+    /// Returns null when the log directory cannot be determined.
+    /// </summary>
+    private string? ArtifactSiblingPath(string suffix)
+    {
+        var dir = Path.GetDirectoryName(_processLogPath);
+        if (string.IsNullOrEmpty(dir))
+        {
+            return null;
+        }
+        return Path.Join(dir, $"{Path.GetFileNameWithoutExtension(_processLogPath)}-{suffix}");
+    }
+
+    /// <summary>
     /// True when the current process runs at High (or System) Integrity Level on Windows.
     /// Uses the mandatory-label SID from <c>whoami /groups</c> rather than
     /// <see cref="Environment.IsPrivilegedProcess"/>, which keys off UAC token elevation and
@@ -635,10 +651,22 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         }
 
         // Set the flag before writing so DisposeAsync reverts the machine policy even if the
-        // add result cannot be parsed; deleting an absent value is a harmless no-op.
+        // verification below throws; deleting an absent value is a harmless no-op.
         _wroteHklmBrowserArgs = true;
-        await RunCaptureAsync("reg",
+        var addOutput = await RunCaptureAsync("reg",
             $@"add ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments /t REG_SZ /d ""{arguments}"" /f");
+
+        // reg can fail without throwing (e.g. access denied / locked-down policy) -- RunCaptureAsync
+        // just returns its output. Confirm the value actually landed and fail fast with the reg
+        // output, rather than letting CDP readiness time out ~30s later with an indirect error.
+        var verify = await RunCaptureAsync("reg", $@"query ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments");
+        if (!Regex.IsMatch(verify, @"AdditionalBrowserArguments\s+REG_", RegexOptions.IgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "Failed to publish the HKLM WebView2 AdditionalBrowserArguments policy required for elevated " +
+                $"CDP (WebView2Feedback #5640).{Environment.NewLine}reg add output: {addOutput}{Environment.NewLine}" +
+                $"reg query output: {verify}");
+        }
     }
 
     /// <summary>

--- a/MonacoEditorComponent.Tests/DesktopAppFixture.cs
+++ b/MonacoEditorComponent.Tests/DesktopAppFixture.cs
@@ -406,6 +406,12 @@ public sealed class DesktopAppFixture : IAsyncLifetime
 
         var sb = new StringBuilder();
 
+        // 0. Integrity level of this process (== the spawned app's IL, since the app is
+        //    launched as a child). WebView2 runtime v150 disables the CDP loopback
+        //    endpoint when the host runs at High Mandatory Level (WebView2Feedback #5640).
+        sb.AppendLine("--- process integrity level (whoami /groups | Mandatory) ---")
+          .AppendLine(await RunCaptureAsync("cmd", "/c whoami /groups | findstr /i Mandatory"));
+
         // 1. DevToolsActivePort: the decisive signal for whether a listener started.
         try
         {

--- a/MonacoEditorComponent.Tests/DesktopAppFixture.cs
+++ b/MonacoEditorComponent.Tests/DesktopAppFixture.cs
@@ -52,7 +52,13 @@ public sealed class DesktopAppFixture : IAsyncLifetime
 
     // Machine-wide WebView2 policy key. Arguments published here survive an elevated host
     // process, unlike the WEBVIEW2_* environment variables (WebView2Feedback #5640).
+    // Per the WebView2 loader contract, AdditionalBrowserArguments is a SUBKEY whose value
+    // is named by the AppId (AUMID / compiled code name), with "*" as the all-apps wildcard --
+    // NOT a value named "AdditionalBrowserArguments" under the WebView2 key. Writing it at the
+    // wrong level is silently ignored by the loader. See CreateCoreWebView2EnvironmentWithOptions.
     private const string WebView2PolicyKey = @"HKLM\SOFTWARE\Policies\Microsoft\Edge\WebView2";
+    private const string WebView2AdditionalArgsKey = WebView2PolicyKey + @"\AdditionalBrowserArguments";
+    private const string WebView2AppIdWildcard = "*";
 
     // In-memory log lines for cursor-based query API.
     private readonly List<string> _logLines = [];
@@ -218,7 +224,7 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         {
             try
             {
-                await RunCaptureAsync("reg", $@"delete ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments /f");
+                await RunCaptureAsync("reg", $@"delete ""{WebView2AdditionalArgsKey}"" /v {WebView2AppIdWildcard} /f");
             }
             catch (InvalidOperationException) { /* best-effort */ }
             catch (Win32Exception) { /* best-effort */ }
@@ -510,8 +516,8 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         //     (WebView2Feedback #5640). Present with our --remote-debugging-port => the
         //     write took effect (so the runtime is ignoring HKLM); absent => the write was
         //     skipped (gate) or failed (perms). Read while still live (DisposeAsync reverts).
-        sb.AppendLine("--- HKLM WebView2 AdditionalBrowserArguments (elevated CDP write) ---")
-          .AppendLine(await RunCaptureAsync("reg", $@"query ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments"));
+        sb.AppendLine("--- HKLM WebView2 AdditionalBrowserArguments\\* (elevated CDP write) ---")
+          .AppendLine(await RunCaptureAsync("reg", $@"query ""{WebView2AdditionalArgsKey}"" /v {WebView2AppIdWildcard}"));
 
         // 3. Is anything listening on the requested port? Match the exact ":{port}" token
         //    (port followed by a non-digit) so e.g. 5000 does not also match 15000/50001.
@@ -639,13 +645,12 @@ public sealed class DesktopAppFixture : IAsyncLifetime
     /// </summary>
     private async Task PublishHklmBrowserArgumentsAsync(string arguments)
     {
-        // Do not clobber a value the machine already defines (the CI runner defines none).
-        var existing = await RunCaptureAsync("reg", $@"query ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments");
-        // Match the actual reg-query success line ("AdditionalBrowserArguments  REG_SZ  ..."),
-        // not a bare substring: RunCaptureAsync's own failure text echoes the queried value
-        // name in the command it reports, so a substring check would read a reg-launch failure
-        // as "value already exists" and skip the write -- leaving CDP broken on elevated runners.
-        if (Regex.IsMatch(existing, @"AdditionalBrowserArguments\s+REG_", RegexOptions.IgnoreCase))
+        // Do not clobber a wildcard value the machine already defines (the CI runner defines none).
+        // Detect it via the REG_ type token on the query's value line, not a bare substring:
+        // RunCaptureAsync's own failure text echoes the queried command, so a substring check
+        // would read a reg-launch failure as "value already exists" and skip the write.
+        var existing = await RunCaptureAsync("reg", $@"query ""{WebView2AdditionalArgsKey}"" /v {WebView2AppIdWildcard}");
+        if (Regex.IsMatch(existing, @"\bREG_", RegexOptions.IgnoreCase))
         {
             return;
         }
@@ -654,13 +659,13 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         // verification below throws; deleting an absent value is a harmless no-op.
         _wroteHklmBrowserArgs = true;
         var addOutput = await RunCaptureAsync("reg",
-            $@"add ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments /t REG_SZ /d ""{arguments}"" /f");
+            $@"add ""{WebView2AdditionalArgsKey}"" /v {WebView2AppIdWildcard} /t REG_SZ /d ""{arguments}"" /f");
 
         // reg can fail without throwing (e.g. access denied / locked-down policy) -- RunCaptureAsync
         // just returns its output. Confirm the value actually landed and fail fast with the reg
         // output, rather than letting CDP readiness time out ~30s later with an indirect error.
-        var verify = await RunCaptureAsync("reg", $@"query ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments");
-        if (!Regex.IsMatch(verify, @"AdditionalBrowserArguments\s+REG_", RegexOptions.IgnoreCase))
+        var verify = await RunCaptureAsync("reg", $@"query ""{WebView2AdditionalArgsKey}"" /v {WebView2AppIdWildcard}");
+        if (!Regex.IsMatch(verify, @"\bREG_", RegexOptions.IgnoreCase))
         {
             throw new InvalidOperationException(
                 "Failed to publish the HKLM WebView2 AdditionalBrowserArguments policy required for elevated " +

--- a/MonacoEditorComponent.Tests/DesktopAppFixture.cs
+++ b/MonacoEditorComponent.Tests/DesktopAppFixture.cs
@@ -111,10 +111,17 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         // ignored -- only HKLM policy and API args are honored (WebView2Feedback #5640,
         // "by design"). The windows-latest CI runner executes elevated, so the
         // --remote-debugging-port set above via WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS is
-        // silently dropped and no CDP listener starts. When elevated, additionally publish
-        // the switch through the HKLM AdditionalBrowserArguments policy, which survives
-        // elevation. Non-elevated (local dev) keeps using the env var and leaves HKLM alone.
-        if (await IsHostHighIntegrityAsync())
+        // silently dropped and no CDP listener starts. There, additionally publish the
+        // switch through the HKLM AdditionalBrowserArguments policy, which survives elevation.
+        //
+        // Restrict this machine-wide write to CI (GITHUB_ACTIONS) on top of the integrity
+        // check: writing HKLM policy affects other WebView2 hosts on the machine and could
+        // linger if the run is interrupted before DisposeAsync reverts it. CI runners are
+        // ephemeral, so that is acceptable there; a developer running elevated locally is not
+        // modified (they keep the env var, which is enough at Medium IL / pre-v150 anyway).
+        var isCi = string.Equals(
+            Environment.GetEnvironmentVariable("GITHUB_ACTIONS"), "true", StringComparison.OrdinalIgnoreCase);
+        if (isCi && await IsHostHighIntegrityAsync())
         {
             await PublishHklmBrowserArgumentsAsync($"--remote-debugging-port={_cdpPort}");
         }
@@ -506,9 +513,10 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         sb.AppendLine("--- HKLM WebView2 AdditionalBrowserArguments (elevated CDP write) ---")
           .AppendLine(await RunCaptureAsync("reg", $@"query ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments"));
 
-        // 3. Is anything listening on the requested port?
+        // 3. Is anything listening on the requested port? Match the exact ":{port}" token
+        //    (port followed by a non-digit) so e.g. 5000 does not also match 15000/50001.
         sb.AppendLine($"--- netstat (port {_cdpPort}) ---")
-          .AppendLine(await RunCaptureAsync("cmd", $"/c netstat -ano -p tcp | findstr {_cdpPort}"));
+          .AppendLine(await RunCaptureAsync("cmd", $"/c netstat -ano -p tcp | findstr /r \":{_cdpPort}[^0-9]\""));
 
         // 4. WebView2 Evergreen runtime version.
         sb.AppendLine("--- WebView2 runtime version ---")

--- a/MonacoEditorComponent.Tests/DesktopAppFixture.cs
+++ b/MonacoEditorComponent.Tests/DesktopAppFixture.cs
@@ -114,7 +114,7 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         // silently dropped and no CDP listener starts. When elevated, additionally publish
         // the switch through the HKLM AdditionalBrowserArguments policy, which survives
         // elevation. Non-elevated (local dev) keeps using the env var and leaves HKLM alone.
-        if (OperatingSystem.IsWindows() && Environment.IsPrivilegedProcess)
+        if (await IsHostHighIntegrityAsync())
         {
             await PublishHklmBrowserArgumentsAsync($"--remote-debugging-port={_cdpPort}");
         }
@@ -498,6 +498,13 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         sb.AppendLine("--- Edge RemoteDebuggingAllowed (HKCU) ---")
           .AppendLine(await RunCaptureAsync("reg", @"query ""HKCU\SOFTWARE\Policies\Microsoft\Edge"" /v RemoteDebuggingAllowed"));
 
+        // 2b. The AdditionalBrowserArguments we publish via HKLM policy for elevated CDP
+        //     (WebView2Feedback #5640). Present with our --remote-debugging-port => the
+        //     write took effect (so the runtime is ignoring HKLM); absent => the write was
+        //     skipped (gate) or failed (perms). Read while still live (DisposeAsync reverts).
+        sb.AppendLine("--- HKLM WebView2 AdditionalBrowserArguments (elevated CDP write) ---")
+          .AppendLine(await RunCaptureAsync("reg", $@"query ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments"));
+
         // 3. Is anything listening on the requested port?
         sb.AppendLine($"--- netstat (port {_cdpPort}) ---")
           .AppendLine(await RunCaptureAsync("cmd", $"/c netstat -ano -p tcp | findstr {_cdpPort}"));
@@ -577,6 +584,24 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         try { return await readTask; }
         catch (OperationCanceledException) { return string.Empty; }
         catch (IOException) { return string.Empty; }
+    }
+
+    /// <summary>
+    /// True when the current process runs at High (or System) Integrity Level on Windows.
+    /// Uses the mandatory-label SID from <c>whoami /groups</c> rather than
+    /// <see cref="Environment.IsPrivilegedProcess"/>, which keys off UAC token elevation and
+    /// returns false on CI runners where UAC is disabled but the process is still High IL --
+    /// the exact condition under which WebView2 v150 drops the WEBVIEW2_* switches (#5640).
+    /// </summary>
+    private static async Task<bool> IsHostHighIntegrityAsync()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+        var groups = await RunCaptureAsync("whoami", "/groups");
+        return groups.Contains("S-1-16-12288", StringComparison.Ordinal)   // High
+            || groups.Contains("S-1-16-16384", StringComparison.Ordinal);  // System
     }
 
     /// <summary>

--- a/MonacoEditorComponent.Tests/DesktopAppFixture.cs
+++ b/MonacoEditorComponent.Tests/DesktopAppFixture.cs
@@ -643,6 +643,18 @@ public sealed class DesktopAppFixture : IAsyncLifetime
     /// only when elevated (the sole case that needs it); best-effort and reverted in
     /// <see cref="DisposeAsync"/>. A pre-existing machine policy value is left untouched.
     /// </summary>
+    /// <remarks>
+    /// SINGLE-WRITER ASSUMPTION: the <c>*</c> wildcard is one machine-global registry slot, but
+    /// each fixture instance picks its own <c>_cdpPort</c>. The write/skip/revert dance here is
+    /// race-free ONLY because the desktop tests share a single, serialized fixture instance via
+    /// <c>[Collection("DesktopCDP")]</c> + <c>ICollectionFixture&lt;DesktopAppFixture&gt;</c> (see
+    /// <c>DesktopCdpCollection</c>). If these tests are ever moved to a per-class
+    /// <c>IClassFixture</c> or split across parallel collections, two concurrent instances would
+    /// collide on this slot: the second would find the first's value, skip its own write, inherit
+    /// the wrong port and time out, and whichever disposes first would delete the value out from
+    /// under the other. Such a refactor must key the value per app/port (or otherwise serialize
+    /// this write) instead of using <c>*</c>.
+    /// </remarks>
     private async Task PublishHklmBrowserArgumentsAsync(string arguments)
     {
         // Do not clobber a wildcard value the machine already defines (the CI runner defines none).

--- a/MonacoEditorComponent.Tests/DesktopAppFixture.cs
+++ b/MonacoEditorComponent.Tests/DesktopAppFixture.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
@@ -25,7 +26,7 @@ namespace MonacoEditorComponent.Tests;
 ///
 /// <para><b>Agent-driven testing pattern (Playwright MCP)</b>:
 /// An AI agent can also connect to a running desktop app for ad-hoc verification
-/// using the Playwright MCP server with <c>--cdp-endpoint http://localhost:{port}</c>.
+/// using the Playwright MCP server with <c>--cdp-endpoint http://127.0.0.1:{port}</c>.
 /// This provides <c>browser_snapshot</c> for accessibility tree inspection,
 /// <c>browser_evaluate</c> for JS assertions, and <c>browser_click</c> for
 /// interaction testing. This is a development convenience, not automated CI.</para>
@@ -370,7 +371,7 @@ public sealed class DesktopAppFixture : IAsyncLifetime
 
             try
             {
-                var response = await httpClient.GetAsync(versionUrl);
+                using var response = await httpClient.GetAsync(versionUrl);
                 if (response.IsSuccessStatusCode)
                 {
                     // Record the runtime that actually answered CDP (the "Browser" field,
@@ -384,7 +385,7 @@ public sealed class DesktopAppFixture : IAsyncLifetime
                         var dir = Path.GetDirectoryName(_processLogPath);
                         if (!string.IsNullOrEmpty(dir))
                         {
-                            await File.WriteAllTextAsync(Path.Combine(dir, "cdp-version.txt"), versionBody);
+                            await File.WriteAllTextAsync(Path.Join(dir, "cdp-version.txt"), versionBody);
                         }
                     }
                     catch { /* best-effort */ }
@@ -463,16 +464,23 @@ public sealed class DesktopAppFixture : IAsyncLifetime
                 }
             }
         }
-        catch (Exception ex)
+        catch (IOException ex)
+        {
+            // Covers DirectoryNotFound/FileNotFound/PathTooLong (all derive from IOException).
+            sb.AppendLine($"DevToolsActivePort probe failed: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
         {
             sb.AppendLine($"DevToolsActivePort probe failed: {ex.Message}");
         }
 
-        // 2. Edge remote-debugging policy (0 => CDP disabled by policy).
-        sb.AppendLine("--- Edge policies (HKLM) ---")
-          .AppendLine(await RunCaptureAsync("reg", @"query ""HKLM\SOFTWARE\Policies\Microsoft\Edge"" /s"));
-        sb.AppendLine("--- Edge policies (HKCU) ---")
-          .AppendLine(await RunCaptureAsync("reg", @"query ""HKCU\SOFTWARE\Policies\Microsoft\Edge"" /s"));
+        // 2. Edge remote-debugging policy (0 => CDP disabled by policy). Query the specific
+        //    value rather than dumping the whole policy tree (/s), which is large and noisy.
+        //    A "unable to find" result means the policy is unset (i.e. not disabling CDP).
+        sb.AppendLine("--- Edge RemoteDebuggingAllowed (HKLM) ---")
+          .AppendLine(await RunCaptureAsync("reg", @"query ""HKLM\SOFTWARE\Policies\Microsoft\Edge"" /v RemoteDebuggingAllowed"));
+        sb.AppendLine("--- Edge RemoteDebuggingAllowed (HKCU) ---")
+          .AppendLine(await RunCaptureAsync("reg", @"query ""HKCU\SOFTWARE\Policies\Microsoft\Edge"" /v RemoteDebuggingAllowed"));
 
         // 3. Is anything listening on the requested port?
         sb.AppendLine($"--- netstat (port {_cdpPort}) ---")
@@ -491,10 +499,11 @@ public sealed class DesktopAppFixture : IAsyncLifetime
             var dir = Path.GetDirectoryName(_processLogPath);
             if (!string.IsNullOrEmpty(dir))
             {
-                await File.WriteAllTextAsync(Path.Combine(dir, "cdp-diagnostics.txt"), diagnostics);
+                await File.WriteAllTextAsync(Path.Join(dir, "cdp-diagnostics.txt"), diagnostics);
             }
         }
-        catch { /* best-effort */ }
+        catch (IOException) { /* best-effort */ }
+        catch (UnauthorizedAccessException) { /* best-effort */ }
 
         return diagnostics;
     }
@@ -502,6 +511,8 @@ public sealed class DesktopAppFixture : IAsyncLifetime
     /// <summary>Runs a console command and returns combined stdout+stderr (best-effort).</summary>
     private static async Task<string> RunCaptureAsync(string fileName, string arguments, int timeoutMs = 10_000)
     {
+        string Failed(Exception ex) => $"(command '{fileName} {arguments}' failed: {ex.Message})";
+
         try
         {
             using var proc = new Process
@@ -517,18 +528,39 @@ public sealed class DesktopAppFixture : IAsyncLifetime
                 },
             };
             proc.Start();
-            var stdoutTask = proc.StandardOutput.ReadToEndAsync();
-            var stderrTask = proc.StandardError.ReadToEndAsync();
+
+            // Bound the stream reads by the same timeout token as the exit wait so a
+            // process that never exits (or whose Kill fails) can't hang log collection
+            // indefinitely -- the reads are cancelled when the token fires.
             using var cts = new CancellationTokenSource(timeoutMs);
-            try { await proc.WaitForExitAsync(cts.Token); }
-            catch (OperationCanceledException) { try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ } }
-            var output = ($"{await stdoutTask}{await stderrTask}").Trim();
+            var stdoutTask = proc.StandardOutput.ReadToEndAsync(cts.Token);
+            var stderrTask = proc.StandardError.ReadToEndAsync(cts.Token);
+            try
+            {
+                await proc.WaitForExitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                try { proc.Kill(entireProcessTree: true); }
+                catch (InvalidOperationException) { /* already exited */ }
+                catch (Win32Exception) { /* OS refused termination */ }
+                catch (NotSupportedException) { /* unsupported on platform */ }
+            }
+
+            var output = $"{await ReadOrEmptyAsync(stdoutTask)}{await ReadOrEmptyAsync(stderrTask)}".Trim();
             return string.IsNullOrEmpty(output) ? "(no output)" : output;
         }
-        catch (Exception ex)
-        {
-            return $"(command '{fileName} {arguments}' failed: {ex.Message})";
-        }
+        catch (Win32Exception ex) { return Failed(ex); }
+        catch (InvalidOperationException ex) { return Failed(ex); }
+        catch (IOException ex) { return Failed(ex); }
+    }
+
+    /// <summary>Awaits a bounded stream read, returning empty on cancellation/I-O failure (best-effort).</summary>
+    private static async Task<string> ReadOrEmptyAsync(Task<string> readTask)
+    {
+        try { return await readTask; }
+        catch (OperationCanceledException) { return string.Empty; }
+        catch (IOException) { return string.Empty; }
     }
 
     /// <summary>
@@ -540,8 +572,23 @@ public sealed class DesktopAppFixture : IAsyncLifetime
     /// </summary>
     private string CaptureLogSnapshot()
     {
+        // Keep only the most recent lines: the tail is the relevant diagnostic near a
+        // failure, and the full buffer can make exceptions unreadably large.
+        const int maxLines = 200;
         var lines = GetLinesAfter(0);
-        return lines.Count > 0 ? string.Join(Environment.NewLine, lines) : "(no log)";
+        if (lines.Count == 0)
+        {
+            return "(no log)";
+        }
+        if (lines.Count <= maxLines)
+        {
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        var omitted = lines.Count - maxLines;
+        var tail = lines.GetRange(lines.Count - maxLines, maxLines);
+        return $"(... {omitted} earlier line(s) omitted; showing last {maxLines} ...)" +
+            Environment.NewLine + string.Join(Environment.NewLine, tail);
     }
 
     private async Task<IPage> FindMonacoPage()

--- a/MonacoEditorComponent.Tests/DesktopAppFixture.cs
+++ b/MonacoEditorComponent.Tests/DesktopAppFixture.cs
@@ -100,6 +100,18 @@ public sealed class DesktopAppFixture : IAsyncLifetime
             },
         };
 
+        // WebView2 runtime v150 disables the CDP loopback endpoint when the host runs at
+        // High Integrity Level (elevated), which is how the windows-latest CI runner
+        // executes -- so --remote-debugging-port silently produces no listener there
+        // (WebView2Feedback #5640). When CI provides a pre-v150 Fixed Version runtime via
+        // WEBVIEW2_BROWSER_EXECUTABLE_FOLDER, forward it so the app uses that runtime and
+        // CDP works again. Unset locally (developers run non-elevated) => Evergreen runtime.
+        var fixedRuntimeFolder = Environment.GetEnvironmentVariable("WEBVIEW2_BROWSER_EXECUTABLE_FOLDER");
+        if (!string.IsNullOrEmpty(fixedRuntimeFolder))
+        {
+            startInfo.Environment["WEBVIEW2_BROWSER_EXECUTABLE_FOLDER"] = fixedRuntimeFolder;
+        }
+
         _appProcess = Process.Start(startInfo)
             ?? throw new InvalidOperationException("Failed to start MonacoEditorTestApp desktop process.");
 
@@ -361,6 +373,21 @@ public sealed class DesktopAppFixture : IAsyncLifetime
                 var response = await httpClient.GetAsync(versionUrl);
                 if (response.IsSuccessStatusCode)
                 {
+                    // Record the runtime that actually answered CDP (the "Browser" field,
+                    // e.g. "Edg/149.0.4022.98"). This is authoritative for which WebView2
+                    // runtime loaded: the machine's Evergreen version in the registry is
+                    // not, once a Fixed Version runtime is pinned via
+                    // WEBVIEW2_BROWSER_EXECUTABLE_FOLDER (WebView2Feedback #5640).
+                    try
+                    {
+                        var versionBody = await response.Content.ReadAsStringAsync();
+                        var dir = Path.GetDirectoryName(_processLogPath);
+                        if (!string.IsNullOrEmpty(dir))
+                        {
+                            await File.WriteAllTextAsync(Path.Combine(dir, "cdp-version.txt"), versionBody);
+                        }
+                    }
+                    catch { /* best-effort */ }
                     return; // CDP is ready.
                 }
             }

--- a/MonacoEditorComponent.Tests/DesktopAppFixture.cs
+++ b/MonacoEditorComponent.Tests/DesktopAppFixture.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 
 using Microsoft.Playwright;
@@ -375,9 +376,126 @@ public sealed class DesktopAppFixture : IAsyncLifetime
             await Task.Delay(CdpPollIntervalMs);
         }
 
+        var cdpDiagnostics = await CollectCdpDiagnosticsAsync();
         throw new TimeoutException(
             $"CDP endpoint at {versionUrl} did not become ready within {CdpReadyTimeoutMs}ms.\n" +
+            $"CDP diagnostics:\n{cdpDiagnostics}\n" +
             $"Process log:\n{CaptureLogSnapshot()}");
+    }
+
+    /// <summary>
+    /// Best-effort, Windows-only diagnostics gathered when the CDP endpoint never became
+    /// ready. Answers the key question the readiness timeout cannot: did WebView2/Chromium
+    /// even start a remote-debugging listener, and if not, why?
+    /// <list type="bullet">
+    /// <item><description><c>DevToolsActivePort</c> present under the user-data folder =&gt;
+    /// the listener started (line 1 is the actual port; if it differs from the requested
+    /// port, the fixture polled the wrong one).</description></item>
+    /// <item><description>Absent =&gt; remote debugging never started (policy or the
+    /// <c>WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS</c> flag was not honored).</description></item>
+    /// <item><description>Edge <c>RemoteDebuggingAllowed</c> policy = 0 disables CDP entirely.</description></item>
+    /// </list>
+    /// Also written to <c>test-artifacts/cdp-diagnostics.txt</c> for the uploaded artifact.
+    /// </summary>
+    private async Task<string> CollectCdpDiagnosticsAsync()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return "(CDP diagnostics collected on Windows only)";
+        }
+
+        var sb = new StringBuilder();
+
+        // 1. DevToolsActivePort: the decisive signal for whether a listener started.
+        try
+        {
+            var found = Directory.Exists(_userDataFolder)
+                ? Directory.GetFiles(_userDataFolder, "DevToolsActivePort", SearchOption.AllDirectories)
+                : [];
+            if (found.Length == 0)
+            {
+                sb.AppendLine("DevToolsActivePort: NOT FOUND under user-data folder " +
+                    "=> remote debugging never started (arg/policy not honored).");
+            }
+            else
+            {
+                foreach (var file in found)
+                {
+                    // Read with FileShare.ReadWrite in case Chromium still holds it open.
+                    using var fs = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    using var reader = new StreamReader(fs);
+                    var content = (await reader.ReadToEndAsync()).Trim();
+                    sb.AppendLine($"DevToolsActivePort ({file}):").AppendLine(content)
+                      .AppendLine($"(requested port was {_cdpPort})");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            sb.AppendLine($"DevToolsActivePort probe failed: {ex.Message}");
+        }
+
+        // 2. Edge remote-debugging policy (0 => CDP disabled by policy).
+        sb.AppendLine("--- Edge policies (HKLM) ---")
+          .AppendLine(await RunCaptureAsync("reg", @"query ""HKLM\SOFTWARE\Policies\Microsoft\Edge"" /s"));
+        sb.AppendLine("--- Edge policies (HKCU) ---")
+          .AppendLine(await RunCaptureAsync("reg", @"query ""HKCU\SOFTWARE\Policies\Microsoft\Edge"" /s"));
+
+        // 3. Is anything listening on the requested port?
+        sb.AppendLine($"--- netstat (port {_cdpPort}) ---")
+          .AppendLine(await RunCaptureAsync("cmd", $"/c netstat -ano -p tcp | findstr {_cdpPort}"));
+
+        // 4. WebView2 Evergreen runtime version.
+        sb.AppendLine("--- WebView2 runtime version ---")
+          .AppendLine(await RunCaptureAsync("reg",
+              @"query ""HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"" /v pv"));
+
+        var diagnostics = sb.ToString();
+
+        // Persist to the uploaded artifacts directory for reliable capture.
+        try
+        {
+            var dir = Path.GetDirectoryName(_processLogPath);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                await File.WriteAllTextAsync(Path.Combine(dir, "cdp-diagnostics.txt"), diagnostics);
+            }
+        }
+        catch { /* best-effort */ }
+
+        return diagnostics;
+    }
+
+    /// <summary>Runs a console command and returns combined stdout+stderr (best-effort).</summary>
+    private static async Task<string> RunCaptureAsync(string fileName, string arguments, int timeoutMs = 10_000)
+    {
+        try
+        {
+            using var proc = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = fileName,
+                    Arguments = arguments,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                },
+            };
+            proc.Start();
+            var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+            var stderrTask = proc.StandardError.ReadToEndAsync();
+            using var cts = new CancellationTokenSource(timeoutMs);
+            try { await proc.WaitForExitAsync(cts.Token); }
+            catch (OperationCanceledException) { try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ } }
+            var output = ($"{await stdoutTask}{await stderrTask}").Trim();
+            return string.IsNullOrEmpty(output) ? "(no output)" : output;
+        }
+        catch (Exception ex)
+        {
+            return $"(command '{fileName} {arguments}' failed: {ex.Message})";
+        }
     }
 
     /// <summary>

--- a/MonacoEditorComponent.Tests/DesktopAppFixture.cs
+++ b/MonacoEditorComponent.Tests/DesktopAppFixture.cs
@@ -213,7 +213,8 @@ public sealed class DesktopAppFixture : IAsyncLifetime
             {
                 await RunCaptureAsync("reg", $@"delete ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments /f");
             }
-            catch { /* best-effort */ }
+            catch (InvalidOperationException) { /* best-effort */ }
+            catch (Win32Exception) { /* best-effort */ }
             _wroteHklmBrowserArgs = false;
         }
     }
@@ -616,7 +617,11 @@ public sealed class DesktopAppFixture : IAsyncLifetime
     {
         // Do not clobber a value the machine already defines (the CI runner defines none).
         var existing = await RunCaptureAsync("reg", $@"query ""{WebView2PolicyKey}"" /v AdditionalBrowserArguments");
-        if (existing.Contains("AdditionalBrowserArguments", StringComparison.OrdinalIgnoreCase))
+        // Match the actual reg-query success line ("AdditionalBrowserArguments  REG_SZ  ..."),
+        // not a bare substring: RunCaptureAsync's own failure text echoes the queried value
+        // name in the command it reports, so a substring check would read a reg-launch failure
+        // as "value already exists" and skip the write -- leaving CDP broken on elevated runners.
+        if (Regex.IsMatch(existing, @"AdditionalBrowserArguments\s+REG_", RegexOptions.IgnoreCase))
         {
             return;
         }


### PR DESCRIPTION
## Problem

The **Desktop Tests (Windows)** CI job failed on every PR: all 39 `DesktopCDP` integration tests errored in `DesktopAppFixture.InitializeAsync` because the CDP endpoint (`http://…/json/version`) never became ready. The failure originated on `main`, not this branch.

## Root cause

WebView2 runtime **v150** hardened how browser switches are accepted when the host process runs **elevated (High Integrity Level)**: switches supplied through **user-writable channels** — the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable and `HKCU` policy — are **silently ignored**; only the machine-wide **`HKLM` policy** and direct API args are honored — see [WebView2Feedback #5640](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5640) ("by design").

GitHub `windows-latest` runs steps **elevated** (confirmed on the runner: `Mandatory Label\High Mandatory Level`), and its Evergreen WebView2 auto-updated to v150. The fixture passed `--remote-debugging-port` via `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS`, which v150 drops under elevation, so `--remote-debugging-port` produced no listener (no `DevToolsActivePort`, `netstat` empty). It works locally because developers run non-elevated (Medium IL), where the env var is still honored.

## Fix

When the host is elevated **and running on CI** (`GITHUB_ACTIONS`), publish `--remote-debugging-port` through the machine-wide WebView2 loader policy, which v150 honors under elevation. Per the WebView2 loader contract, the argument lives in the **`…\Edge\WebView2\AdditionalBrowserArguments` subkey** under a value named by AppId — the fixture uses the `*` all-apps wildcard. The fixture:

- Detects High Integrity Level via the mandatory-label SID from `whoami /groups` — not `Environment.IsPrivilegedProcess`, which keys off UAC token elevation and returns false on CI runners where UAC is disabled but the process is still High IL (the exact condition that triggers #5640).
- Writes the HKLM policy only when elevated **and** on CI, and only when the machine defines no existing `*` value; it verifies the write actually landed (fails fast with the `reg` output otherwise) and reverts its own write in `DisposeAsync`.
- Leaves local dev unchanged: non-elevated runs use the `WEBVIEW2_*` env var, and the HKLM write never happens off CI.

No CI workflow change is required beyond running the tests — the runner's pre-installed Evergreen WebView2 + Edge are used as-is.

> **✅ Verified green.** Desktop Tests (Windows) passes on commit `d3c7c88`. Reaching green required fixing a registry-layout bug: an earlier revision wrote a value literally *named* `AdditionalBrowserArguments` directly under the `WebView2` key, which the loader never reads — so the value was present in the registry but silently ignored, and CDP never started. `AdditionalBrowserArguments` is a **subkey** whose value is keyed by AppId (`*` = all apps); writing the switch there is what actually enables remote debugging under elevation.

### Also fixed en route (pre-existing on `main`)

- **Masked diagnostic:** the readiness-timeout path read the process log with `File.ReadAllText` while the background writer held it open, throwing an `IOException` that hid the real error. Now reads the in-memory log buffer (last 200 lines).
- **CDP endpoint:** poll/connect over `127.0.0.1` instead of `localhost` (matches the loopback port reservation; avoids IPv6 `::1` mismatch).
- Added on-timeout CDP diagnostics (`DevToolsActivePort`, integrity level, Edge `RemoteDebuggingAllowed` policy, `netstat`, runtime version) to `test-artifacts/` for future triage.

## Follow-up

Writing an `HKLM` policy relies on the elevated context CI already runs in; the fixture reverts it after the run. If a future WebView2 release honors the `WEBVIEW2_*` env var under elevation again (or the fixture launches the app de-elevated at Medium IL), the HKLM path can be dropped.
