### PR TITLE
build: drop git commit suffix from main package versions

### DIFF
--- a/version.json
+++ b/version.json
@@ -5,6 +5,7 @@
     "semVer": 2.0
   },
   "publicReleaseRefSpec": [
+    "^refs/heads/main$",
     "^refs/heads/uno",
     "^refs/heads/feature/.*$",
     "^refs/heads/release/stable/\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
## What

Mark `main` as a public-release ref in `version.json` so Nerdbank.GitVersioning (NBGV) omits the `.g<sha>` git commit id from the NuGet package version on **Publish Dev** builds.

| | Before | After |
|---|---|---|
| Package version on `main` | `6.5.0-dev.335.gc6f90eed90` | `6.5.0-dev.335` |

## Why

NBGV appends the git commit id to the package version only when a build is **not** a "public release" (`PublicRelease=false`), to keep versions unique across branches. Packages are published from `main` (Publish Dev) and `release/stable/N` (Publish Production), but `main` was missing from `publicReleaseRefSpec`, so dev-feed packages carried the `.g<sha>` suffix. Stable releases were already covered by the existing `release/stable/N` entry.

The `-dev.{height}` prerelease tag is retained — height alone is unique on a single branch, so the commit-id disambiguator isn't needed.

## Verification

Confirmed locally with `nbgv get-version` (v3.8.118, pinned) building on `main` with the change committed:

```
PublicRelease      : True
NuGetPackageVersion: 6.5.0-dev.336   ← no .g<sha> suffix
```

(height shown as `336` due to a throwaway measurement commit; real publishes read `6.5.0-dev.335`, `.336`, …)

## Note

The workflow also triggers production publish on `release/*/*` broadly, but only `release/stable/N` is in `publicReleaseRefSpec`. Non-stable release branches (e.g. `release/beta/*`) would still carry the suffix — out of scope here, easy to broaden later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
