### PR TITLE
perf: shrink shipped JS payload by 89% and fix packaged desktop content path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Monaco Editor version: **0.52.2** (declared `^0.52.2` in `package.json`; resolve
 - **CI pipeline**: migrated from Azure Pipelines to GitHub Actions with NuGet signing
 - **Versioning**: switched to Nerdbank.GitVersioning
 - **Build system**: migrated to `.slnx` solution format, modernized `Directory.Build.props`
+- **Production JS bundles**: one-shot esbuild builds are now minified with no source maps (watch builds stay unminified with inline maps), cutting the bundled JavaScript from 46.7 MB to 12.8 MB; `--no-minify`, `--minify`, and `--sourcemap` override the defaults
 
 ### Deprecated
 
@@ -61,9 +62,11 @@ Monaco Editor version: **0.52.2** (declared `^0.52.2` in `package.json`; resolve
 - **Legacy `GenerateMonacoTypings` MSBuild target**: replaced by the new `ts-morph` + .NET CLI emitter pipeline
 - **AMD script loading**: replaced by ESM module bundling with esbuild
 - **`build/` directory**: stale build artifacts directory removed
+- **Worker bundles as WASM embedded resources**: the five Monaco language-worker bundles are no longer embedded for WebAssembly. Uno flattens `WasmScripts\workers\*.worker.js` to dot-joined names while `MonacoEnvironment.getWorkerUrl` resolves them under a `workers/` subdirectory, so they always 404 and Monaco fell back to main-thread language services — they were ~8.5 MB of unreachable payload. Desktop is unaffected
 
 ### Fixed
 
+- Fix `DirectoryNotFoundException` on desktop when the control is consumed from the NuGet package: `DesktopContent` is now probed at both `<output>/DesktopContent` and `<output>/MonacoEditorComponent/DesktopContent` (the layout `GenerateLibraryLayout` produces), and the probe requires `editor.html` rather than merely the directory
 - Fix `automaticLayout` replacing buggy manual `window.resize` handling ([#27](https://github.com/unoplatform/uno.monaco.editor/pull/27))
 - Fix redundant DOM Loading subscription affecting Playground ([#26](https://github.com/unoplatform/uno.monaco.editor/pull/26))
 - Fix highlighting not working ([#25](https://github.com/unoplatform/uno.monaco.editor/pull/25))

--- a/MonacoEditorComponent.Tests/TryResolveDesktopContentPathTests.cs
+++ b/MonacoEditorComponent.Tests/TryResolveDesktopContentPathTests.cs
@@ -1,0 +1,172 @@
+using Monaco;
+
+using Xunit;
+
+namespace MonacoEditorComponent.Tests;
+
+/// <summary>
+/// Tests for <see cref="DesktopCodeEditorPresenter.TryResolveDesktopContentPath"/> and
+/// <see cref="DesktopCodeEditorPresenter.GetDesktopContentCandidates"/>.
+/// Validates the two-candidate probe that locates the desktop content root:
+/// <c>&lt;base&gt;/DesktopContent</c> (ProjectReference output) and
+/// <c>&lt;base&gt;/&lt;AssemblyName&gt;/DesktopContent</c> (NuGet package output, produced by
+/// Uno's <c>GenerateLibraryLayout=true</c> asset packing).
+/// </summary>
+public sealed class TryResolveDesktopContentPathTests : IDisposable
+{
+    /// <summary>The assembly-name prefix Uno uses for library-layout assets.</summary>
+    private const string LibraryFolder = "MonacoEditorComponent";
+
+    private const string ContentFolder = "DesktopContent";
+
+    private readonly string _baseDirectory;
+
+    public TryResolveDesktopContentPathTests()
+    {
+        _baseDirectory = Path.Combine(Path.GetTempPath(), $"monaco-content-probe-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_baseDirectory);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_baseDirectory, recursive: true); }
+        catch { /* best effort cleanup */ }
+    }
+
+    /// <summary>
+    /// Creates a candidate folder under the temp base directory, optionally writing
+    /// <c>editor.html</c> into it. Returns the created folder path.
+    /// </summary>
+    private string CreateContentFolder(string relativePath, bool withEditorHtml)
+    {
+        var folder = Path.Combine(_baseDirectory, relativePath);
+        Directory.CreateDirectory(folder);
+        if (withEditorHtml)
+        {
+            File.WriteAllText(Path.Combine(folder, "editor.html"), "<html></html>");
+        }
+
+        return folder;
+    }
+
+    [Fact]
+    public void RootOnlyLayout_ReturnsRootFolder()
+    {
+        var expected = CreateContentFolder(ContentFolder, withEditorHtml: true);
+
+        Assert.Equal(expected, DesktopCodeEditorPresenter.TryResolveDesktopContentPath(
+            baseDirectory: _baseDirectory,
+            libraryLayoutFolderName: LibraryFolder));
+    }
+
+    [Fact]
+    public void LibraryLayoutOnly_ReturnsNestedFolder()
+    {
+        // The NuGet package deploys content ONLY here (GenerateLibraryLayout=true).
+        var expected = CreateContentFolder(Path.Combine(LibraryFolder, ContentFolder), withEditorHtml: true);
+
+        Assert.Equal(expected, DesktopCodeEditorPresenter.TryResolveDesktopContentPath(
+            baseDirectory: _baseDirectory,
+            libraryLayoutFolderName: LibraryFolder));
+    }
+
+    [Fact]
+    public void BothLayoutsPresent_PrefersRootFolder()
+    {
+        // A ProjectReference build produces BOTH layouts from the same source files.
+        // Root-first keeps that existing resolution unchanged.
+        var root = CreateContentFolder(ContentFolder, withEditorHtml: true);
+        CreateContentFolder(Path.Combine(LibraryFolder, ContentFolder), withEditorHtml: true);
+
+        Assert.Equal(root, DesktopCodeEditorPresenter.TryResolveDesktopContentPath(
+            baseDirectory: _baseDirectory,
+            libraryLayoutFolderName: LibraryFolder));
+    }
+
+    [Fact]
+    public void NeitherLayoutPresent_ReturnsNull()
+    {
+        Assert.Null(DesktopCodeEditorPresenter.TryResolveDesktopContentPath(
+            baseDirectory: _baseDirectory,
+            libraryLayoutFolderName: LibraryFolder));
+    }
+
+    [Fact]
+    public void RootFolderWithoutEditorHtml_FallsBackToLibraryLayout()
+    {
+        // A stale or empty DesktopContent must not win: it would produce a blank WebView2.
+        CreateContentFolder(ContentFolder, withEditorHtml: false);
+        var expected = CreateContentFolder(Path.Combine(LibraryFolder, ContentFolder), withEditorHtml: true);
+
+        Assert.Equal(expected, DesktopCodeEditorPresenter.TryResolveDesktopContentPath(
+            baseDirectory: _baseDirectory,
+            libraryLayoutFolderName: LibraryFolder));
+    }
+
+    [Fact]
+    public void AllFoldersWithoutEditorHtml_ReturnsNull()
+    {
+        // Directory.Exists would have selected one of these; File.Exists must not.
+        CreateContentFolder(ContentFolder, withEditorHtml: false);
+        CreateContentFolder(Path.Combine(LibraryFolder, ContentFolder), withEditorHtml: false);
+
+        Assert.Null(DesktopCodeEditorPresenter.TryResolveDesktopContentPath(
+            baseDirectory: _baseDirectory,
+            libraryLayoutFolderName: LibraryFolder));
+    }
+
+    [Fact]
+    public void RenamedLibraryFolder_ProbesSuppliedFolderName()
+    {
+        // The library-layout prefix is Uno's $(AssemblyName), so the probe must use the
+        // supplied name rather than a hardcoded "MonacoEditorComponent".
+        const string renamed = "SomeRenamedAssembly";
+        var expected = CreateContentFolder(Path.Combine(renamed, ContentFolder), withEditorHtml: true);
+
+        Assert.Equal(expected, DesktopCodeEditorPresenter.TryResolveDesktopContentPath(
+            baseDirectory: _baseDirectory,
+            libraryLayoutFolderName: renamed));
+
+        Assert.Null(DesktopCodeEditorPresenter.TryResolveDesktopContentPath(
+            baseDirectory: _baseDirectory,
+            libraryLayoutFolderName: LibraryFolder));
+    }
+
+    [Fact]
+    public void GetDesktopContentCandidates_RootBeforeLibraryLayout()
+    {
+        var candidates = DesktopCodeEditorPresenter.GetDesktopContentCandidates(
+            baseDirectory: _baseDirectory,
+            libraryLayoutFolderName: LibraryFolder);
+
+        Assert.Equal(
+            [
+                Path.Combine(_baseDirectory, ContentFolder),
+                Path.Combine(_baseDirectory, LibraryFolder, ContentFolder),
+            ],
+            candidates);
+    }
+
+    /// <summary>
+    /// Pins the contract that Uno's library-layout prefix is <c>$(AssemblyName)</c>: if the
+    /// assembly is ever renamed, the derived probe folder must follow it.
+    /// </summary>
+    [Fact]
+    public void AssemblyName_MatchesLibraryLayoutFolderName()
+    {
+        Assert.Equal(LibraryFolder, typeof(DesktopCodeEditorPresenter).Assembly.GetName().Name);
+    }
+
+    /// <summary>
+    /// The resolved root is assigned to <c>AllowedFileContentRoot</c>, so it must gate
+    /// <see cref="DesktopCodeEditorPresenter.IsNavigationAllowed"/> for the library layout too.
+    /// </summary>
+    [Fact]
+    public void LibraryLayoutRoot_GatesFileNavigation()
+    {
+        var root = CreateContentFolder(Path.Combine(LibraryFolder, ContentFolder), withEditorHtml: true);
+
+        Assert.True(DesktopCodeEditorPresenter.IsNavigationAllowed(
+            DesktopCodeEditorPresenter.BuildFileEditorUri(root).ToString(), root));
+    }
+}

--- a/MonacoEditorComponent.Tests/TryResolveDesktopContentPathTests.cs
+++ b/MonacoEditorComponent.Tests/TryResolveDesktopContentPathTests.cs
@@ -29,8 +29,12 @@ public sealed class TryResolveDesktopContentPathTests : IDisposable
 
     public void Dispose()
     {
+        // Best effort cleanup: a temp folder still held by the OS (IOException) or denied by ACLs
+        // (UnauthorizedAccessException) must not fail the test run. Anything else is a real bug
+        // and is deliberately left to propagate.
         try { Directory.Delete(_baseDirectory, recursive: true); }
-        catch { /* best effort cleanup */ }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
     }
 
     /// <summary>

--- a/MonacoEditorComponent.Tests/TryResolveDesktopContentPathTests.cs
+++ b/MonacoEditorComponent.Tests/TryResolveDesktopContentPathTests.cs
@@ -29,12 +29,11 @@ public sealed class TryResolveDesktopContentPathTests : IDisposable
 
     public void Dispose()
     {
-        // Best effort cleanup: a temp folder still held by the OS (IOException) or denied by ACLs
-        // (UnauthorizedAccessException) must not fail the test run. Anything else is a real bug
+        // Best effort cleanup: anything other than the two tolerated cases below is a real bug
         // and is deliberately left to propagate.
         try { Directory.Delete(_baseDirectory, recursive: true); }
-        catch (IOException) { }
-        catch (UnauthorizedAccessException) { }
+        catch (IOException) { /* temp folder still held by the OS; not a test failure */ }
+        catch (UnauthorizedAccessException) { /* cleanup denied by ACLs; not a test failure */ }
     }
 
     /// <summary>

--- a/MonacoEditorComponent/CodeEditor/DesktopCodeEditorPresenter.cs
+++ b/MonacoEditorComponent/CodeEditor/DesktopCodeEditorPresenter.cs
@@ -620,17 +620,9 @@ namespace Monaco
         /// be selected and yield a silently blank WebView2, which is worse than a clear failure.</para>
         /// </summary>
         internal static string? TryResolveDesktopContentPath(string baseDirectory, string libraryLayoutFolderName)
-        {
-            foreach (var candidate in GetDesktopContentCandidates(baseDirectory, libraryLayoutFolderName))
-            {
-                if (File.Exists(Path.Combine(candidate, EditorPageFileName)))
-                {
-                    return candidate;
-                }
-            }
-
-            return null;
-        }
+            => GetDesktopContentCandidates(baseDirectory, libraryLayoutFolderName)
+                .Where(candidate => File.Exists(Path.Combine(candidate, EditorPageFileName)))
+                .FirstOrDefault();
 
         /// <summary>
         /// Resolves the DesktopContent folder for the running application. Content ships either at

--- a/MonacoEditorComponent/CodeEditor/DesktopCodeEditorPresenter.cs
+++ b/MonacoEditorComponent/CodeEditor/DesktopCodeEditorPresenter.cs
@@ -571,17 +571,107 @@ namespace Monaco
         // ============================================================
 
         /// <summary>
-        /// Resolves the DesktopContent folder path from the application's base directory.
-        /// Content files are copied to output via CopyToOutputDirectory="PreserveNewest".
+        /// The editor host page file name inside the DesktopContent folder. Shared by the
+        /// content-root probe and both navigation URI builders, so the file the probe requires
+        /// is exactly the file navigation targets.
         /// </summary>
+        private const string EditorPageFileName = "editor.html";
+
+        /// <summary>
+        /// The main Monaco bundle file name inside the DesktopContent folder. Used only for a
+        /// non-fatal completeness diagnostic; deliberately NOT part of the content-root
+        /// selection predicate (see <see cref="TryResolveDesktopContentPath"/>).
+        /// </summary>
+        private const string HelpersScriptFileName = "uno-monaco-helpers.js";
+
+        /// <summary>The DesktopContent folder name, relative to a candidate root.</summary>
+        private const string DesktopContentFolderName = "DesktopContent";
+
+        /// <summary>
+        /// Returns the candidate DesktopContent roots to probe, in priority order:
+        /// <list type="number">
+        /// <item><c>&lt;baseDirectory&gt;/DesktopContent</c> — produced by a
+        /// <c>ProjectReference</c> to this library, or by a consumer copying the content itself.</item>
+        /// <item><c>&lt;baseDirectory&gt;/&lt;libraryLayoutFolderName&gt;/DesktopContent</c> —
+        /// produced by the NuGet package. <c>GenerateLibraryLayout=true</c> makes Uno pack library
+        /// content under <c>lib/&lt;tfm&gt;/$(AssemblyName)/</c>, and the consumer-side asset
+        /// expansion re-creates that same <c>$(AssemblyName)</c> prefix in both the build output
+        /// and the publish directory.</item>
+        /// </list>
+        /// Root-first is deliberate: a <c>ProjectReference</c> build produces BOTH layouts, so
+        /// probing the root first leaves the existing resolution untouched and makes the
+        /// library-layout probe a pure addition.
+        /// </summary>
+        /// <param name="baseDirectory">The application base directory (normally <see cref="AppContext.BaseDirectory"/>).</param>
+        /// <param name="libraryLayoutFolderName">The Uno library-layout prefix, which is this assembly's simple name.</param>
+        internal static string[] GetDesktopContentCandidates(string baseDirectory, string libraryLayoutFolderName)
+            =>
+            [
+                Path.Combine(baseDirectory, DesktopContentFolderName),
+                Path.Combine(baseDirectory, libraryLayoutFolderName, DesktopContentFolderName),
+            ];
+
+        /// <summary>
+        /// Probes <see cref="GetDesktopContentCandidates"/> in order and returns the first
+        /// candidate that actually contains <c>editor.html</c>, or <see langword="null"/> when
+        /// none does.
+        /// <para>The predicate is the presence of the entry file, not the presence of the
+        /// directory: a present-but-empty or stale <c>DesktopContent</c> directory would otherwise
+        /// be selected and yield a silently blank WebView2, which is worse than a clear failure.</para>
+        /// </summary>
+        internal static string? TryResolveDesktopContentPath(string baseDirectory, string libraryLayoutFolderName)
+        {
+            foreach (var candidate in GetDesktopContentCandidates(baseDirectory, libraryLayoutFolderName))
+            {
+                if (File.Exists(Path.Combine(candidate, EditorPageFileName)))
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Resolves the DesktopContent folder for the running application. Content ships either at
+        /// <c>&lt;base&gt;/DesktopContent</c> (ProjectReference) or at
+        /// <c>&lt;base&gt;/&lt;AssemblyName&gt;/DesktopContent</c> (NuGet package, because
+        /// <c>GenerateLibraryLayout=true</c> nests library assets under the assembly name). Both
+        /// are probed; the library-layout folder name is derived from this assembly's name so it
+        /// follows an assembly rename automatically.
+        /// </summary>
+        /// <exception cref="DirectoryNotFoundException">
+        /// Thrown when neither candidate contains <c>editor.html</c>.
+        /// </exception>
         private static string ResolveDesktopContentPath()
         {
-            var contentRoot = Path.Combine(AppContext.BaseDirectory, "DesktopContent");
-            if (!Directory.Exists(contentRoot))
+            var libraryLayoutFolderName =
+                typeof(DesktopCodeEditorPresenter).Assembly.GetName().Name ?? "MonacoEditorComponent";
+
+            var contentRoot = TryResolveDesktopContentPath(AppContext.BaseDirectory, libraryLayoutFolderName);
+            if (contentRoot is null)
             {
-                throw new DirectoryNotFoundException(
-                    $"DesktopContent folder not found at {contentRoot}. " +
-                    "Ensure the MonacoEditorComponent NuGet package content files are present.");
+                var message = new StringBuilder($"Monaco {EditorPageFileName} not found. Probed:");
+                foreach (var candidate in GetDesktopContentCandidates(AppContext.BaseDirectory, libraryLayoutFolderName))
+                {
+                    message.Append(Environment.NewLine)
+                           .Append("  ")
+                           .Append(Path.Combine(candidate, EditorPageFileName));
+                }
+
+                message.Append(Environment.NewLine)
+                       .Append("Ensure the Uno.Monaco.Editor package content files are deployed to the application ")
+                       .Append("output directory (they ship under the assembly-name subfolder when the package is ")
+                       .Append("consumed via PackageReference).");
+
+                throw new DirectoryNotFoundException(message.ToString());
+            }
+
+            if (!File.Exists(Path.Combine(contentRoot, HelpersScriptFileName)))
+            {
+                Debug.WriteLine(
+                    $"DesktopCodeEditorPresenter: {HelpersScriptFileName} is missing from {contentRoot} — " +
+                    "the editor page will load blank.");
             }
 
             return contentRoot;
@@ -624,10 +714,10 @@ namespace Monaco
         /// which works reliably on all WebView2 implementations.
         /// </summary>
         internal static global::System.Uri BuildVirtualHostEditorUri()
-            => new($"http://{AllowedVirtualHost}/editor.html");
+            => new($"http://{AllowedVirtualHost}/{EditorPageFileName}");
 
         internal static global::System.Uri BuildFileEditorUri(string contentRoot)
-            => new(Path.Combine(contentRoot, "editor.html"));
+            => new(Path.Combine(contentRoot, EditorPageFileName));
 
         internal static bool ShouldFallbackToFileNavigation(
             bool isSuccess,

--- a/MonacoEditorComponent/MonacoEditorComponent.csproj
+++ b/MonacoEditorComponent/MonacoEditorComponent.csproj
@@ -88,6 +88,15 @@
 		rather than the type:'module' Monaco 0.52 requests by default). Desktop is unaffected:
 		it gets its worker copies from the Content items below, next to editor.html, where a real
 		"workers/" subdirectory does exist.
+
+		OPEN QUESTION, do not treat the CSS entry below as verified: the shell task keys CSS off a
+		separate "WasmCSS" folder prefix, so a .css under WasmScripts appears to be dropped. It is
+		absent from config.uno_dependencies, absent from wwwroot/package_<hash>/, and never
+		requested in the dev-server log, which suggests it is dead payload in the same way the
+		workers were. It was NOT removed here because, unlike the workers, no browser check has
+		confirmed the visual consequence: Monaco also injects theme CSS at runtime via
+		createStyleSheet, so the editor may render correctly without it. Resolve by checking
+		whether the file must move to a WasmCSS folder or can simply be dropped for WASM.
 	-->
 	<ItemGroup>
 		<EmbeddedResource Include="Properties\MonacoEditorComponent.rd.xml" />

--- a/MonacoEditorComponent/MonacoEditorComponent.csproj
+++ b/MonacoEditorComponent/MonacoEditorComponent.csproj
@@ -67,16 +67,32 @@
 		<None Remove="tsconfig.json" />
 	</ItemGroup>
 
-	<!-- WASM: EmbeddedResource for main bundle + CSS + workers -->
+	<!--
+		WASM: EmbeddedResource for main bundle + CSS.
+
+		The five worker bundles are deliberately NOT embedded. Uno.Wasm.Bootstrap's shell task
+		flattens WasmScripts\workers\ts.worker.js to the dot-joined name "workers.ts.worker.js"
+		in wwwroot/package_<hash>/, but MonacoEnvironment.getWorkerUrl (ts-helpermethods/index.ts)
+		resolves workers as "<scriptBase>workers/<name>.js" with a slash. No "workers/" directory
+		exists in the deployed output, so every worker request 404s and Monaco falls back to
+		main-thread language services. Verified in a browser: all five URLs returned 404 while
+		the flattened name returned 200, forcing a JSON model produced no markers, and Monaco
+		logged "Could not create web worker(s)".
+
+		Embedding them therefore cost ~8.5 MB of download, main-thread parse time and resident
+		WASM linear memory for files that can never run as workers, and executing each bundle on
+		the main thread clobbered window.onmessage five times during boot.
+
+		Re-add these entries together with the fix to the URL/name mismatch (and prefer a
+		getWorker override over getWorkerUrl, so the worker is constructed as a classic script
+		rather than the type:'module' Monaco 0.52 requests by default). Desktop is unaffected:
+		it gets its worker copies from the Content items below, next to editor.html, where a real
+		"workers/" subdirectory does exist.
+	-->
 	<ItemGroup>
 		<EmbeddedResource Include="Properties\MonacoEditorComponent.rd.xml" />
 		<EmbeddedResource Include="WasmScripts\uno-monaco-helpers.js" />
 		<EmbeddedResource Include="WasmScripts\uno-monaco-helpers.css" Condition="Exists('WasmScripts\uno-monaco-helpers.css')" />
-		<EmbeddedResource Include="WasmScripts\workers\editor.worker.js" Condition="Exists('WasmScripts\workers\editor.worker.js')" />
-		<EmbeddedResource Include="WasmScripts\workers\json.worker.js" Condition="Exists('WasmScripts\workers\json.worker.js')" />
-		<EmbeddedResource Include="WasmScripts\workers\css.worker.js" Condition="Exists('WasmScripts\workers\css.worker.js')" />
-		<EmbeddedResource Include="WasmScripts\workers\html.worker.js" Condition="Exists('WasmScripts\workers\html.worker.js')" />
-		<EmbeddedResource Include="WasmScripts\workers\ts.worker.js" Condition="Exists('WasmScripts\workers\ts.worker.js')" />
 	</ItemGroup>
 
 	<!-- Desktop: Content files copied to output directory -->

--- a/MonacoEditorComponent/ts-helpermethods/esbuild.config.mjs
+++ b/MonacoEditorComponent/ts-helpermethods/esbuild.config.mjs
@@ -10,7 +10,19 @@
  *
  * Usage:
  *   node MonacoEditorComponent/ts-helpermethods/esbuild.config.mjs
+ *       Production build (one-shot): minified, no source maps. This is what every call
+ *       site uses -- `npm run build`, the MSBuild targets in MonacoEditorComponent.csproj,
+ *       install-dependencies.ps1, and CI.
  *   node MonacoEditorComponent/ts-helpermethods/esbuild.config.mjs --watch
+ *       Development build: unminified, inline source maps, rebuild on change.
+ *
+ * Overrides (apply to both modes):
+ *   --no-minify   Force minification off (debuggable one-shot build).
+ *   --minify      Force minification on; wins over --no-minify. Useful as
+ *                 `--watch --minify --sourcemap` to reproduce a minification-only bug
+ *                 in a fast rebuild loop.
+ *   --sourcemap   Force inline source maps on. There is deliberately no --no-sourcemap:
+ *                 one-shot builds never emit maps unless asked.
  */
 
 import * as esbuild from 'esbuild';
@@ -29,7 +41,16 @@ const desktopContentDir = path.join(componentDir, 'DesktopContent');
 const desktopWorkersDir = path.join(desktopContentDir, 'workers');
 
 const isWatch = process.argv.includes('--watch');
-const isMinify = process.argv.includes('--minify');
+
+// Watch = development: unminified with inline source maps, for debuggability.
+// One-shot = production: minified, no source maps. Every call site invokes this script
+// with no flags (npm run build, the MSBuild targets, install-dependencies.ps1, CI), so the
+// production intent has to live in the default rather than in the callers.
+// --minify wins over --no-minify so `--watch --minify --sourcemap` stays a usable debug
+// loop for problems that only reproduce in minified output.
+const isMinify = process.argv.includes('--minify')
+    || (!isWatch && !process.argv.includes('--no-minify'));
+const mainSourcemap = (isWatch || process.argv.includes('--sourcemap')) ? 'inline' : false;
 
 // Ensure output directories exist
 fs.mkdirSync(workersDir, { recursive: true });
@@ -118,6 +139,12 @@ const commonOptions = {
     platform: 'browser',
     logLevel: 'info',
     minify: isMinify,
+    // Keep third-party license banners (/*! ... */, @license, @preserve) in a block at the
+    // end of every output file. This is already esbuild's default when bundle: true; it is
+    // pinned explicitly because these bundles redistribute Monaco (MIT) and the TypeScript
+    // compiler (Apache-2.0), and that attribution must not silently disappear if esbuild's
+    // default changes or someone sets 'none' while tuning output size.
+    legalComments: 'eof',
     // Monaco ESM distribution includes .ttf font files via CSS @font-face
     // Use dataurl to inline fonts directly into the CSS output (avoids separate file serving)
     loader: {
@@ -140,22 +167,28 @@ async function build() {
         ...commonOptions,
         entryPoints: [path.join(__dirname, 'index.ts')],
         outfile: path.join(wasmScriptsDir, 'uno-monaco-helpers.js'),
-        sourcemap: 'inline',
+        sourcemap: mainSourcemap,
         // Resolve vscode-jsonrpc from its browser entry
         conditions: ['browser', 'import'],
         // Resolve node_modules from root
         nodePaths: [path.join(rootDir, 'node_modules')],
     };
 
-    // Build worker bundles (output to WasmScripts/workers/)
-    const workerBuildOptions = Object.entries(workerEntries).map(([name, entry]) => ({
+    // Build worker bundles (output to WasmScripts/workers/).
+    // Factory so the one-shot path and the watch path cannot drift apart.
+    const createWorkerBuildOptions = (name, entry) => ({
         ...commonOptions,
         entryPoints: [entry],
         outfile: path.join(workersDir, `${name}.js`),
-        // No source maps for workers (not needed for debugging)
+        // No source maps for workers in any mode, including watch: these are third-party
+        // Monaco/TypeScript bundles that are never debugged from source here, and the maps
+        // would dominate their size.
         sourcemap: false,
         nodePaths: [path.join(rootDir, 'node_modules')],
-    }));
+    });
+
+    const workerBuildOptions = Object.entries(workerEntries)
+        .map(([name, entry]) => createWorkerBuildOptions(name, entry));
 
     if (isWatch) {
         // Watch mode: rebuild on change, copy to DesktopContent after each rebuild.
@@ -168,20 +201,16 @@ async function build() {
         console.log('[esbuild] Watching main bundle for changes...');
 
         for (const [name, entry] of Object.entries(workerEntries)) {
-            const opts = {
-                ...commonOptions,
-                entryPoints: [entry],
-                outfile: path.join(workersDir, `${name}.js`),
-                sourcemap: false,
-                nodePaths: [path.join(rootDir, 'node_modules')],
+            const ctx = await esbuild.context({
+                ...createWorkerBuildOptions(name, entry),
                 plugins: [createCopyWorkerPlugin(name)],
-            };
-            const ctx = await esbuild.context(opts);
+            });
             await ctx.watch();
         }
         console.log('[esbuild] Watching worker bundles for changes...');
     } else {
         // Single build
+        console.log(`[esbuild] Mode: ${isMinify ? 'minified' : 'unminified'}, source maps: ${mainSourcemap || 'none'}.`);
         console.log('[esbuild] Building main bundle...');
         await esbuild.build(mainBuildOptions);
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -410,6 +410,8 @@ flowchart TD
 
 The JavaScript side is built as a single IIFE bundle (`uno-monaco-helpers.js`) from `MonacoEditorComponent/ts-helpermethods/index.ts` using esbuild.
 
+**Build modes:** a one-shot build (`npm run build`, the MSBuild targets, `install-dependencies.ps1`, CI) is a production build — minified, no source maps, third-party license banners preserved at end-of-file (`legalComments: 'eof'`). `npm run build:watch` is a development build — unminified with inline source maps. Overrides: `--no-minify`, `--minify`, `--sourcemap` (or `npm run build:dev` for an unminified, mapped one-shot build). Note that MSBuild only compares timestamps, so run `npm run build` before a Release build or `dotnet pack` if you last ran a watch/dev build.
+
 **Module layout:**
 
 | Module | Responsibility |

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Build tooling for Uno Monaco Editor component",
   "scripts": {
     "build": "node MonacoEditorComponent/ts-helpermethods/esbuild.config.mjs",
+    "build:dev": "node MonacoEditorComponent/ts-helpermethods/esbuild.config.mjs --no-minify --sourcemap",
     "build:watch": "node MonacoEditorComponent/ts-helpermethods/esbuild.config.mjs --watch"
   },
   "dependencies": {


### PR DESCRIPTION
## What

Four fixes to the shipped payload and one packaging bug, from a downstream measurement of
`Uno.Monaco.Editor` 6.5.0-dev.337 that put the control at ~117 MB on a WebAssembly app's boot path.

| | Before | After |
|---|---|---|
| Bundled JS (per copy) | 46,654,210 B | **12,799,750 B** (−72.6%) |
| `MonacoEditorComponent.dll` | 47,529,984 B | **5,198,336 B** (−89.1%) |

Three separable deltas: **−20,593,325** sourcemap removal, **−13,261,135** minification, **−8,478,720**
worker resource removal.

## Commits

- **`fix(desktop): probe library-layout DesktopContent path`** — `ResolveDesktopContentPath` only probed
  `AppContext.BaseDirectory/DesktopContent`, which never exists for a NuGet consumer:
  `GenerateLibraryLayout=true` packs library content at `lib/<tfm>/$(AssemblyName)/` and the consumer-side
  asset expansion recreates that prefix in build *and* publish output, so every packaged desktop app threw
  `DirectoryNotFoundException` on first use. In-repo builds use a `ProjectReference`, which produces both
  layouts — which is exactly why local runs and the Desktop CDP suite never caught it. Now probes both,
  root-first so existing resolution is unchanged, and requires `editor.html` rather than merely the
  directory (a stale or empty `DesktopContent` would otherwise be selected and yield a silently blank
  WebView2 — worse than a clear failure).
- **`perf(build): minify bundles and drop inline sourcemap`** — the main bundle shipped a 20.2 MB inline
  base64 sourcemap (69% of its 29.2 MB), and all six bundles shipped unminified because `minify` was gated
  on a `--minify` flag no call site passed. One-shot builds are now production builds; `--watch` stays a
  dev build with inline maps. `--no-minify` / `--minify` / `--sourcemap` override, and `npm run build:dev`
  gives a debuggable one-shot build.
- **`perf(wasm): stop embedding unreachable worker bundles`** — see below.
- **`docs(wasm): flag uno-monaco-helpers.css as unverified-as-served`** plus a CHANGELOG commit.

### Why the default had to move into the esbuild config

CI runs `npm install && npm run build` *before* `dotnet build` in all three jobs, so
`BuildMonacoBundlesWhenSourcesChange` is always skipped there (outputs newer than inputs). Adding
`--minify` to the csproj `Exec` would have been dead code in CI; the production intent has to live in the
config default instead.

### The worker bundles were not merely eager — they were unreachable

Uno's shell task flattens `WasmScripts\workers\ts.worker.js` to the dot-joined `workers.ts.worker.js` in
`wwwroot/package_<hash>/`, but `MonacoEnvironment.getWorkerUrl` resolves workers as
`<scriptBase>workers/<name>.js` with a slash, and no `workers/` directory exists in the deployed output.

Confirmed in a browser before removing anything: all five worker URLs returned **404** while the flattened
name returned **200**; forcing a JSON model produced no markers; and Monaco logged `Could not create web
worker(s). Falling back to loading web worker code in main thread`. So ~8.5 MB was downloaded, parsed and
held resident for files that could never run as workers — and executing each bundle on the main thread
clobbered `window.onmessage` five times during boot.

Language services on WASM were already dead, so removal is functionally neutral there. It does **not**
restore them: that needs a `getWorker` override (Monaco 0.52 sets `isESM = true` and otherwise requests
`{type:'module'}` against our IIFE bundles) plus a deploy path that keeps the files out of
`config.uno_dependencies`. Recorded in the csproj comment for whoever picks it up. Desktop is unaffected —
it gets its copies from the `Content` items, next to `editor.html`, where a real `workers/` directory does
exist.

## Verification

- 260 unit tests pass, including 10 new ones for the content-path probe (untraited, so they run on all
  three CI jobs)
- Library and test project build with 0 warnings under `TreatWarningsAsErrors`
- WASM Playwright suite passes **in a real browser against the minified bundle**
- Byte-level gates: no sourcemap comments remain; the `Bundled license information` blocks and the
  Apache-2.0 TypeScript notice survive (`legalComments: 'eof'` is pinned explicitly, since these bundles
  redistribute Monaco and the TypeScript compiler); the codicon `.ttf` is still inlined in the minified
  CSS; all 47 `globalThis.*` names that `[JSImport]` binds **by name** are preserved; minified output
  parses
- Both flag branches smoke-tested (`build:dev` produces an unminified mapped bundle; `--watch` starts both
  contexts)

### Not verified — please weigh this in review

The desktop fix compiles and its logic is unit-tested, but the **end-to-end proof that it fixes the
packaged failure has not run**. That gate is: build `release_net10.0-desktop`, rename
`<outdir>/DesktopContent` aside so only the nested layout remains, then run the `Category=DesktopCDP` suite
pre- and post-fix. It was blocked locally by a broken .NET workload install (workload set `10.0.302.1`
missing its manifests), which prevents building the test app for `net10.0-browserwasm` / `net10.0-desktop`.
The unit tests use synthetic directories; the real deployed layout was confirmed by inspecting the
published `6.5.0-dev.337` package and the desktop build output, not by running the app.

CI has working workloads, so the Desktop CDP and WASM suites here should provide coverage the local run
could not.

## Follow-ups, deliberately not in this PR

- Make WASM workers actually work (URL/name mismatch + a deploy path outside `uno_dependencies`)
- `uno-monaco-helpers.css` looks like the same class of dead payload — Uno keys CSS off a separate
  `WasmCSS` prefix, so a `.css` under `WasmScripts` appears never to be served (237 KB of the remaining
  5.20 MB). Left in place and flagged as an open question, because no browser check confirmed the visual
  consequence — Monaco also injects theme CSS at runtime.
- Pre-existing latent bug: `[JSImport("globalThis.getSrc")]` / `setSrc` (`WasmCodeEditorPresenter.cs:176-179`)
  bind to JS functions present in neither the TS sources nor the bundle, yet are called from the `Source`
  getter/setter. Verified against the pre-change bundle that this is not a minification regression.
- Scoping `DesktopContent` away from WASM consumers is not achievable with an item `Condition` (single-TFM
  project, transitively-flowing content); it needs a consumer-side `buildTransitive` targets file.

## Note for reviewers

Watch and one-shot builds now differ by ~24 MB while MSBuild compares only timestamps, so a local
`build:watch` followed by `dotnet build -c Release` or `dotnet pack` would embed the dev bundle. CI is
immune (it always runs `npm run build` first). Mitigated by a build-mode log line and a note in
`docs/architecture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
