### PR TITLE
fix(wasm): stop duplicate color decorations

### DIFF
--- a/MonacoEditorComponent.Tests/ModelHelperScriptTests.cs
+++ b/MonacoEditorComponent.Tests/ModelHelperScriptTests.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+
+using Monaco;
+using Monaco.Editor;
+
+using Xunit;
+
+namespace MonacoEditorComponent.Tests;
+
+/// <summary>
+/// Pins the argument order of the <c>model.find*</c> scripts.
+///
+/// <para>These calls used to go through <c>InvokeScriptAsync(method, args)</c>, which emits
+/// <c>method(element, ...args)</c> so the host can resolve the editor element. That is correct for
+/// the helper functions in <c>ts-helpermethods</c> (they all take the element first) but wrong for a
+/// Monaco API, where it shifts every argument by one: Monaco read the DOM element as the search
+/// pattern -- stringified to <c>[object HTMLDivElement]</c>, a character class that matches an
+/// isolated space -- and <c>captureMatches</c> as the result limit. Every search therefore reported
+/// one bogus match at the first space-delimited character, which the sample app's color provider
+/// turned into a black colorpicker decoration.</para>
+/// </summary>
+public sealed class ModelHelperScriptTests
+{
+    [Fact]
+    public void BuildFindMatchesScript_PassesArgumentsInMonacoOrder()
+    {
+        var script = ModelHelper.BuildFindMatchesScript(
+            searchString: "#[A-Fa-f0-9]{8}",
+            searchOnlyEditableRange: true,
+            isRegex: true,
+            matchCase: true,
+            wordSeparators: null,
+            captureMatches: true,
+            limitResultCount: 999);
+
+        Assert.Equal(
+            "EditorContext.getEditorForElement(element).model.findMatches(\"#[A-Fa-f0-9]{8}\", true, true, true, null, true, 999);",
+            script);
+    }
+
+    [Fact]
+    public void BuildFindMatchesScript_DoesNotPassTheElementAsTheSearchPattern()
+    {
+        var script = ModelHelper.BuildFindMatchesScript(
+            searchString: "needle",
+            searchOnlyEditableRange: true,
+            isRegex: false,
+            matchCase: false,
+            wordSeparators: null,
+            captureMatches: false,
+            limitResultCount: 999);
+
+        Assert.StartsWith(
+            "EditorContext.getEditorForElement(element).model.findMatches(\"needle\"",
+            script);
+        Assert.DoesNotContain("findMatches(element", script);
+    }
+
+    [Fact]
+    public void BuildFindMatchesScript_SerializesWordSeparatorsAsAString()
+    {
+        var script = ModelHelper.BuildFindMatchesScript(
+            searchString: "needle",
+            searchOnlyEditableRange: true,
+            isRegex: false,
+            matchCase: false,
+            wordSeparators: " \t.,",
+            captureMatches: false,
+            limitResultCount: 100);
+
+        Assert.Contains("\" \\t.,\"", script);
+        Assert.EndsWith(", 100);", script);
+    }
+
+    /// <summary>
+    /// The pattern is interpolated into a script that the WASM host evaluates, so it has to survive
+    /// as a JS string literal. Before the argument shift was fixed no caller-supplied pattern ever
+    /// reached Monaco intact, which makes this the first path where the escaping actually matters.
+    /// </summary>
+    [Fact]
+    public void BuildFindMatchesScript_EscapesCharactersThatWouldBreakTheScript()
+    {
+        var lineSeparator = (char)0x2028;
+        var paragraphSeparator = (char)0x2029;
+        var lineFeed = (char)10;
+        var pattern = $"a{lineSeparator}b{paragraphSeparator}c{lineFeed}d\"e\\f";
+
+        var script = ModelHelper.BuildFindMatchesScript(
+            pattern,
+            searchOnlyEditableRange: true,
+            isRegex: true,
+            matchCase: true,
+            wordSeparators: null,
+            captureMatches: true,
+            limitResultCount: 999);
+
+        // A raw line terminator (LF, U+2028 or U+2029) inside the literal is a JS syntax error.
+        Assert.DoesNotContain(lineSeparator, script);
+        Assert.DoesNotContain(paragraphSeparator, script);
+        Assert.DoesNotContain(lineFeed, script);
+
+        // ... and the emitted literal still has to decode back to the caller's pattern, so
+        // quotes and backslashes cannot have ended it early.
+        const string prefix = "EditorContext.getEditorForElement(element).model.findMatches(";
+        var literal = script[prefix.Length..];
+        literal = literal[..literal.IndexOf(", true, true, true, null, true, 999);", StringComparison.Ordinal)];
+
+        Assert.Equal(pattern, JsonSerializer.Deserialize<string>(literal));
+    }
+
+    [Theory]
+    [InlineData("findNextMatch")]
+    [InlineData("findPreviousMatch")]
+    public void BuildFindMatchScript_PassesArgumentsInMonacoOrder(string method)
+    {
+        var script = ModelHelper.BuildFindMatchScript(
+            method,
+            searchString: "needle",
+            searchStart: new Position(3, 5),
+            isRegex: false,
+            matchCase: true,
+            wordSeparators: null,
+            captureMatches: true);
+
+        Assert.Equal(
+            $"EditorContext.getEditorForElement(element).model.{method}(\"needle\", {{\"column\":5,\"lineNumber\":3}}, false, true, null, true);",
+            script);
+    }
+}

--- a/MonacoEditorComponent.Tests/WasmIntegrationTests.cs
+++ b/MonacoEditorComponent.Tests/WasmIntegrationTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.Playwright;
 
+using Monaco.Editor;
+
 using Xunit;
 
 namespace MonacoEditorComponent.Tests;
@@ -170,6 +172,105 @@ public sealed class WasmIntegrationTests : IAsyncLifetime
                 DiffLanguageTokenizationCases.Sample);
 
             Assert.Equal(DiffLanguageTokenizationCases.ExpectedTokens, tokenTypes);
+        }
+        catch
+        {
+            _testFailed = true;
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// The sample app registers a document-color provider that searches the model for 8-digit hex
+    /// literals. <c>Content.txt</c> has none, so the search must come back empty. It did not: the
+    /// script was invoked as <c>findMatches(element, ...)</c>, which shifted every argument by one
+    /// and left Monaco compiling the stringified DOM element into a regex. Running the real script
+    /// against the real model is the only way to catch that -- the C# side happily deserializes the
+    /// bogus match either way.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "WasmPlaywright")]
+    public async Task FindMatches_ScriptSentByModelHelperMatchesNothingWhenThePatternIsAbsent()
+    {
+        _currentTestName = nameof(FindMatches_ScriptSentByModelHelperMatchesNothingWhenThePatternIsAbsent);
+        try
+        {
+            var script = ModelHelper.BuildFindMatchesScript(
+                searchString: "#[A-Fa-f0-9]{8}",
+                searchOnlyEditableRange: true,
+                isRegex: true,
+                matchCase: true,
+                wordSeparators: null,
+                captureMatches: true,
+                limitResultCount: 999);
+
+            // Mirrors the WASM host, which evals the script with `element` bound to the editor's div.
+            var matches = await _fixture.Page.EvaluateAsync<string>(
+                """
+                (s) => {
+                    const element = [...EditorContext._editors.keys()][0];
+                    return JSON.stringify(eval(s));
+                }
+                """,
+                script);
+
+            Assert.Equal("[]", matches);
+        }
+        catch
+        {
+            _testFailed = true;
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Provider registrations live on the page-global <c>monaco.languages</c> registry, which every
+    /// editor on a WASM page shares. Each new editor used to add its own document-color provider and
+    /// Monaco concatenated all of their results, so the same color produced one stacked colorpicker
+    /// decoration per open editor. Registering repeatedly must leave exactly one live provider.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "WasmPlaywright")]
+    public async Task ColorProvider_RepeatedRegistrationKeepsASingleProvider()
+    {
+        _currentTestName = nameof(ColorProvider_RepeatedRegistrationKeepsASingleProvider);
+        try
+        {
+            var roundTrips = await _fixture.Page.EvaluateAsync<int>(
+                """
+                async () => {
+                    const element = [...EditorContext._editors.keys()][0];
+                    const context = EditorContext.getEditorForElement(element);
+                    const accessor = context.Accessor;
+                    const original = accessor.callEvent.bind(accessor);
+                    let calls = 0;
+                    accessor.callEvent = (name, p1, p2) => {
+                        if (String(name).startsWith('ProvideDocumentColors')) { calls++; }
+                        return original(name, p1, p2);
+                    };
+
+                    try {
+                        // Stand in for three more editors loading and registering the same provider.
+                        globalThis.registerColorProvider(element, 'csharp');
+                        globalThis.registerColorProvider(element, 'csharp');
+                        globalThis.registerColorProvider(element, 'csharp');
+                        await new Promise(r => setTimeout(r, 2000));
+
+                        // Force exactly one color computation and count the managed round-trips.
+                        calls = 0;
+                        const model = context.model;
+                        const value = model.getValue();
+                        model.setValue(value + String.fromCharCode(10));
+                        await new Promise(r => setTimeout(r, 2000));
+                        model.setValue(value);
+                        return calls;
+                    } finally {
+                        accessor.callEvent = original;
+                    }
+                }
+                """);
+
+            Assert.Equal(1, roundTrips);
         }
         catch
         {

--- a/MonacoEditorComponent/Monaco/LanguagesHelper.cs
+++ b/MonacoEditorComponent/Monaco/LanguagesHelper.cs
@@ -156,8 +156,6 @@ namespace Monaco
             if (_editor.TryGetTarget(out var editor)
                 && editor._parentAccessor is not null)
             {
-                Console.WriteLine($"Register color provider: {languageId}/{editor.GetHashCode():X8}");
-
                 // link:registerColorProvider.ts:ProvideColorPresentations
                 editor._parentAccessor.RegisterEvent("ProvideColorPresentations" + languageId, async (args) =>
                 {

--- a/MonacoEditorComponent/Monaco/ModelHelper.cs
+++ b/MonacoEditorComponent/Monaco/ModelHelper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 
 using Monaco.Serialization;
@@ -41,7 +42,9 @@ public sealed class ModelHelper(CodeEditor editor) : IModel
     {
         if (_editor.TryGetTarget(out var editor))
         {
-            return await editor.InvokeScriptAsync<IEnumerable<FindMatch>>("EditorContext.getEditorForElement(element).model.findMatches", [searchString, searchOnlyEditableRange, isRegex, matchCase, wordSeparators, captureMatches, limitResultCount]).AsAsyncOperation();
+            var script = BuildFindMatchesScript(searchString, searchOnlyEditableRange, isRegex, matchCase, wordSeparators, captureMatches, limitResultCount);
+
+            return await editor.SendScriptAsync<IEnumerable<FindMatch>>(script) ?? [];
         }
 
         return [];
@@ -51,7 +54,9 @@ public sealed class ModelHelper(CodeEditor editor) : IModel
     {
         if (_editor.TryGetTarget(out var editor))
         {
-            return await editor.InvokeScriptAsync<IEnumerable<FindMatch>>("EditorContext.getEditorForElement(element).model.findMatches", [searchString, searchScope, isRegex, matchCase, wordSeparators, captureMatches, limitResultCount]).AsAsyncOperation();
+            var script = BuildFindMatchesScript(searchString, searchScope, isRegex, matchCase, wordSeparators, captureMatches, limitResultCount);
+
+            return await editor.SendScriptAsync<IEnumerable<FindMatch>>(script) ?? [];
         }
 
         return [];
@@ -61,7 +66,9 @@ public sealed class ModelHelper(CodeEditor editor) : IModel
     {
         if (_editor.TryGetTarget(out var editor))
         {
-            return await editor.InvokeScriptAsync<FindMatch>("EditorContext.getEditorForElement(element).model.findNextMatch", [searchString, searchStart, isRegex, matchCase, wordSeparators, captureMatches]).AsAsyncOperation();
+            var script = BuildFindMatchScript("findNextMatch", searchString, searchStart, isRegex, matchCase, wordSeparators, captureMatches);
+
+            return await editor.SendScriptAsync<FindMatch>(script);
         }
 
         return null;
@@ -71,7 +78,9 @@ public sealed class ModelHelper(CodeEditor editor) : IModel
     {
         if (_editor.TryGetTarget(out var editor))
         {
-            return await editor.InvokeScriptAsync<FindMatch>("EditorContext.getEditorForElement(element).model.findPreviousMatch", [searchString, searchStart, isRegex, matchCase, wordSeparators, captureMatches]).AsAsyncOperation();
+            var script = BuildFindMatchScript("findPreviousMatch", searchString, searchStart, isRegex, matchCase, wordSeparators, captureMatches);
+
+            return await editor.SendScriptAsync<FindMatch>(script);
         }
 
         return null;
@@ -383,4 +392,56 @@ public sealed class ModelHelper(CodeEditor editor) : IModel
 
         return null;
     }
+
+    /// <summary>
+    /// Builds a <c>model.findMatches(...)</c> call.
+    /// </summary>
+    /// <remarks>
+    /// These scripts are sent with <c>SendScriptAsync</c>, not <c>InvokeScriptAsync</c>: the latter
+    /// emits <c>method(element, ...args)</c> so the host can resolve the editor element, which shifts
+    /// every argument by one when the target is a Monaco API rather than one of our helper functions.
+    /// Monaco then read the DOM element as the search pattern (<c>[object HTMLDivElement]</c>, a
+    /// character class that matches an isolated space) and <c>true</c> as the result limit, so every
+    /// search reported one bogus match instead of none.
+    /// </remarks>
+    internal static string BuildFindMatchesScript(string searchString, bool searchOnlyEditableRange, bool isRegex, bool matchCase, string? wordSeparators, bool captureMatches, double limitResultCount)
+        => BuildFindMatchesScript(searchString, JsArg(searchOnlyEditableRange), isRegex, matchCase, wordSeparators, captureMatches, limitResultCount);
+
+    /// <inheritdoc cref="BuildFindMatchesScript(string, bool, bool, bool, string?, bool, double)"/>
+    internal static string BuildFindMatchesScript(string searchString, IRange searchScope, bool isRegex, bool matchCase, string? wordSeparators, bool captureMatches, double limitResultCount)
+        => BuildFindMatchesScript(searchString, JsArg(searchScope), isRegex, matchCase, wordSeparators, captureMatches, limitResultCount);
+
+    private static string BuildFindMatchesScript(string searchString, string searchScope, bool isRegex, bool matchCase, string? wordSeparators, bool captureMatches, double limitResultCount)
+        => "EditorContext.getEditorForElement(element).model.findMatches("
+            + JsArg(searchString) + ", "
+            + searchScope + ", "
+            + JsArg(isRegex) + ", "
+            + JsArg(matchCase) + ", "
+            + JsArg(wordSeparators) + ", "
+            + JsArg(captureMatches) + ", "
+            + JsArg(limitResultCount) + ");";
+
+    /// <summary>
+    /// Builds a <c>model.findNextMatch(...)</c> / <c>model.findPreviousMatch(...)</c> call.
+    /// </summary>
+    /// <remarks>See <see cref="BuildFindMatchesScript(string, bool, bool, bool, string?, bool, double)"/> for why these are not invoked as methods.</remarks>
+    internal static string BuildFindMatchScript(string method, string searchString, IPosition searchStart, bool isRegex, bool matchCase, string? wordSeparators, bool captureMatches)
+        => "EditorContext.getEditorForElement(element).model." + method + "("
+            + JsArg(searchString) + ", "
+            + JsArg(searchStart) + ", "
+            + JsArg(isRegex) + ", "
+            + JsArg(matchCase) + ", "
+            + JsArg(wordSeparators) + ", "
+            + JsArg(captureMatches) + ");";
+
+    private static string JsArg(string? value)
+        => value is null ? "null" : JsonSerializer.Serialize(value, MonacoJsonContext.Relaxed.Options);
+
+    private static string JsArg(bool value) => value ? "true" : "false";
+
+    private static string JsArg(double value) => value.ToString(CultureInfo.InvariantCulture);
+
+    private static string JsArg(IRange range) => JsonSerializer.Serialize(Range.Lift(range), MonacoJsonContext.Relaxed.Range);
+
+    private static string JsArg(IPosition position) => JsonSerializer.Serialize(Position.Lift(position), MonacoJsonContext.Relaxed.Position);
 }

--- a/MonacoEditorComponent/ts-helpermethods/otherScriptsToBeOrganized.ts
+++ b/MonacoEditorComponent/ts-helpermethods/otherScriptsToBeOrganized.ts
@@ -1,6 +1,7 @@
 import * as monaco from 'monaco-editor';
 import { ParentAccessor } from './Monaco.Helpers.ParentAccessor';
 import { callParentEventAsync } from './asyncCallbackHelpers';
+import { callProviderEventAsync, registerSingleProvider } from './providerRegistrations';
 
 export class EditorContext {
     static _editors: Map<any, EditorContext> = new Map<any, EditorContext>();
@@ -64,20 +65,11 @@ export class EditorContext {
     public modifingSelection: boolean;
 }
 
-const hoverProviderRegistrations = new Map<string, monaco.IDisposable>();
-
 export const registerHoverProvider = function (unused: any, languageId: string) {
-    const existing = hoverProviderRegistrations.get(languageId);
-    if (existing) {
-        existing.dispose();
-        hoverProviderRegistrations.delete(languageId);
-    }
-
-    const disposable = monaco.languages.registerHoverProvider(languageId, {
+    return registerSingleProvider('hover', languageId, () => monaco.languages.registerHoverProvider(languageId, {
         provideHover: async function (model, position) {
-            var element = EditorContext.getElementFromModel(model);
             try {
-                const result = await callParentEventAsync(element, "HoverProvider" + languageId, [JSON.stringify(position)]);
+                const result = await callProviderEventAsync(model, "HoverProvider" + languageId, [JSON.stringify(position)]);
                 if (result) {
                     return JSON.parse(result);
                 }
@@ -86,17 +78,7 @@ export const registerHoverProvider = function (unused: any, languageId: string) 
             }
             return undefined;
         }
-    });
-
-    hoverProviderRegistrations.set(languageId, disposable);
-    return {
-        dispose: () => {
-            disposable.dispose();
-            if (hoverProviderRegistrations.get(languageId) === disposable) {
-                hoverProviderRegistrations.delete(languageId);
-            }
-        }
-    };
+    }));
 };
 
 export const addAction = function (element: any, action: monaco.editor.IActionDescriptor) {

--- a/MonacoEditorComponent/ts-helpermethods/providerRegistrations.ts
+++ b/MonacoEditorComponent/ts-helpermethods/providerRegistrations.ts
@@ -1,0 +1,62 @@
+import * as monaco from 'monaco-editor';
+import { EditorContext } from './otherScriptsToBeOrganized';
+import { callParentEventAsync } from './asyncCallbackHelpers';
+
+/**
+ * Monaco language-feature providers live on the page-global `monaco.languages` registry,
+ * not on an editor instance. On WASM every CodeEditor shares one document -- and therefore
+ * one Monaco module -- so each editor that registers a provider for a language adds another
+ * entry to that registry, and Monaco concatenates the results of all of them. Four editors
+ * meant four document-color providers all reporting the same range, which Monaco rendered as
+ * four stacked colorpicker decorations on every line that had a color.
+ *
+ * The providers below resolve their owning editor from the model they are handed, so a single
+ * registration already serves every editor on the page. Keeping exactly one registration per
+ * (kind, language) preserves behaviour for the first editor and stops the duplication for the
+ * ones that follow. On desktop each editor owns its own WebView (and its own module instance),
+ * so the map never holds more than one entry there.
+ */
+const registrations = new Map<string, monaco.IDisposable>();
+
+/**
+ * Registers a provider, replacing any previous registration of the same kind for the same
+ * language. The returned disposable removes the registration and forgets it.
+ */
+export function registerSingleProvider(
+    kind: string,
+    languageId: string,
+    register: () => monaco.IDisposable): monaco.IDisposable {
+
+    const key = `${kind}:${languageId}`;
+    registrations.get(key)?.dispose();
+
+    const disposable = register();
+    registrations.set(key, disposable);
+
+    return {
+        dispose: () => {
+            disposable.dispose();
+            if (registrations.get(key) === disposable) {
+                registrations.delete(key);
+            }
+        }
+    };
+}
+
+/**
+ * Routes a provider callback to the managed side of the editor that owns <paramref name="model"/>.
+ * Returns null when the model belongs to no known editor -- Monaco may ask a provider about
+ * models the component never created (peek views, the suggest widget's detail model, ...).
+ */
+export function callProviderEventAsync(
+    model: monaco.editor.ITextModel,
+    name: string,
+    parameters: string[]): Promise<string | null> {
+
+    const element = EditorContext.getElementFromModel(model);
+    if (!element) {
+        return Promise.resolve(null);
+    }
+
+    return callParentEventAsync(element, name, parameters);
+}

--- a/MonacoEditorComponent/ts-helpermethods/registerCodeActionProvider.ts
+++ b/MonacoEditorComponent/ts-helpermethods/registerCodeActionProvider.ts
@@ -1,16 +1,14 @@
 import * as monaco from 'monaco-editor';
-import { EditorContext } from './otherScriptsToBeOrganized';
-import { callParentEventAsync } from './asyncCallbackHelpers';
+import { callProviderEventAsync, registerSingleProvider } from './providerRegistrations';
 
 function isTextEdit(edit: monaco.languages.IWorkspaceTextEdit | monaco.languages.IWorkspaceFileEdit): edit is monaco.languages.IWorkspaceTextEdit {
     return (edit as monaco.languages.IWorkspaceTextEdit).textEdit !== undefined;
 }
 
 export const registerCodeActionProvider = function (unused: any, languageId: string) {
-    return monaco.languages.registerCodeActionProvider(languageId, {
+    return registerSingleProvider('codeAction', languageId, () => monaco.languages.registerCodeActionProvider(languageId, {
         provideCodeActions: function (model, range, context, token) {
-            var element = EditorContext.getElementFromModel(model);
-            return callParentEventAsync(element, "ProvideCodeActions" + languageId, [JSON.stringify(range), JSON.stringify(context)]).then(result => {
+            return callProviderEventAsync(model, "ProvideCodeActions" + languageId, [JSON.stringify(range), JSON.stringify(context)]).then(result => {
                 if (result) {
                     const list: monaco.languages.CodeActionList = JSON.parse(result);
 
@@ -37,5 +35,5 @@ export const registerCodeActionProvider = function (unused: any, languageId: str
                 }
             });
         },
-    });
+    }));
 }

--- a/MonacoEditorComponent/ts-helpermethods/registerCodeLensProvider.ts
+++ b/MonacoEditorComponent/ts-helpermethods/registerCodeLensProvider.ts
@@ -1,12 +1,10 @@
 import * as monaco from 'monaco-editor';
-import { EditorContext } from './otherScriptsToBeOrganized';
-import { callParentEventAsync } from './asyncCallbackHelpers';
+import { callProviderEventAsync, registerSingleProvider } from './providerRegistrations';
 
 export const registerCodeLensProvider = function (unused: any, languageId: string) {
-    return monaco.languages.registerCodeLensProvider(languageId, {
+    return registerSingleProvider('codeLens', languageId, () => monaco.languages.registerCodeLensProvider(languageId, {
         provideCodeLenses: function (model, token) {
-            var element = EditorContext.getElementFromModel(model);
-            return callParentEventAsync(element, "ProvideCodeLenses" + languageId, []).then(result => {
+            return callProviderEventAsync(model, "ProvideCodeLenses" + languageId, []).then(result => {
                 if (result) {
                     const list: monaco.languages.CodeLensList = JSON.parse(result);
 
@@ -19,13 +17,12 @@ export const registerCodeLensProvider = function (unused: any, languageId: strin
             });
         },
         resolveCodeLens: function (model, codeLens, token) {
-            var element = EditorContext.getElementFromModel(model);
-            return callParentEventAsync(element, "ResolveCodeLens" + languageId, [JSON.stringify(codeLens)]).then(result => {
+            return callProviderEventAsync(model, "ResolveCodeLens" + languageId, [JSON.stringify(codeLens)]).then(result => {
                 if (result) {
                     return JSON.parse(result);
                 }
                 return null;
             });
         }
-    });
+    }));
 }

--- a/MonacoEditorComponent/ts-helpermethods/registerColorProvider.ts
+++ b/MonacoEditorComponent/ts-helpermethods/registerColorProvider.ts
@@ -1,26 +1,21 @@
 import * as monaco from 'monaco-editor';
-import { EditorContext } from './otherScriptsToBeOrganized';
-import { callParentEventAsync } from './asyncCallbackHelpers';
+import { callProviderEventAsync, registerSingleProvider } from './providerRegistrations';
 
 export const registerColorProvider = function (unused: any, languageId: string) {
-    return monaco.languages.registerColorProvider(languageId, {
+    return registerSingleProvider('color', languageId, () => monaco.languages.registerColorProvider(languageId, {
         provideColorPresentations: function (model, colorInfo, token) {
-            var element = EditorContext.getElementFromModel(model);
-
-            return callParentEventAsync(element, "ProvideColorPresentations" + languageId, [JSON.stringify(colorInfo)]).then(result => {
+            return callProviderEventAsync(model, "ProvideColorPresentations" + languageId, [JSON.stringify(colorInfo)]).then(result => {
                 if (result) {
                     return JSON.parse(result);
                 }
             });
         },
         provideDocumentColors: function (model, token) {
-            var element = EditorContext.getElementFromModel(model);
-
-            return callParentEventAsync(element, "ProvideDocumentColors" + languageId, []).then(result => {
+            return callProviderEventAsync(model, "ProvideDocumentColors" + languageId, []).then(result => {
                 if (result) {
                     return JSON.parse(result);
                 }
             });
         }
-    });
+    }));
 }

--- a/MonacoEditorComponent/ts-helpermethods/registerCompletionItemProvider.ts
+++ b/MonacoEditorComponent/ts-helpermethods/registerCompletionItemProvider.ts
@@ -1,30 +1,39 @@
 import * as monaco from 'monaco-editor';
-import { EditorContext } from './otherScriptsToBeOrganized';
-import { callParentEventAsync, stringifyForMarshalling } from './asyncCallbackHelpers';
+import { callProviderEventAsync, registerSingleProvider } from './providerRegistrations';
 
-export const registerCompletionItemProvider = function (element: any, languageId: string, characters: string[]) {
-    var editorContext = EditorContext.getEditorForElement(element);
+export const registerCompletionItemProvider = function (unused: any, languageId: string, characters: string[]) {
+    return registerSingleProvider('completionItem', languageId, () => {
+        // Monaco hands resolveCompletionItem an item but no model, so remember the model the
+        // items were produced for -- that is the editor the resolve request has to go back to.
+        let lastModel: monaco.editor.ITextModel | null = null;
 
-    return monaco.languages.registerCompletionItemProvider(languageId, {
-        triggerCharacters: characters,
-        provideCompletionItems: function (model, position, context, token) {
-            return callParentEventAsync(element, "CompletionItemProvider" + languageId, [JSON.stringify(position), JSON.stringify(context)]).then(result => {
-                if (result) {
-                    const list: monaco.languages.CompletionList = JSON.parse(result);
+        return monaco.languages.registerCompletionItemProvider(languageId, {
+            triggerCharacters: characters,
+            provideCompletionItems: function (model, position, context, token) {
+                lastModel = model;
 
-                    // Add dispose method for IDisposable that Monaco is looking for.
-                    list.dispose = () => { };
+                return callProviderEventAsync(model, "CompletionItemProvider" + languageId, [JSON.stringify(position), JSON.stringify(context)]).then(result => {
+                    if (result) {
+                        const list: monaco.languages.CompletionList = JSON.parse(result);
 
-                    return list;
+                        // Add dispose method for IDisposable that Monaco is looking for.
+                        list.dispose = () => { };
+
+                        return list;
+                    }
+                });
+            },
+            resolveCompletionItem: function (item, token) {
+                if (!lastModel) {
+                    return undefined;
                 }
-            });
-        },
-        resolveCompletionItem: function (item, token) {
-            return callParentEventAsync(element, "CompletionItemRequested" + languageId, [JSON.stringify(item)]).then(result => {
-                if (result) {
-                    return JSON.parse(result);
-                }
-            });
-        }
+
+                return callProviderEventAsync(lastModel, "CompletionItemRequested" + languageId, [JSON.stringify(item)]).then(result => {
+                    if (result) {
+                        return JSON.parse(result);
+                    }
+                });
+            }
+        });
     });
 }


### PR DESCRIPTION
Stacked on #47 (`dev/xygu/20260824/fix-wasm-css-delivery`).

On WASM, every editor rendered a colorpicker swatch after the first word of line 1, and each additional editor instance added one more — a 4th tab showed 3 stacked swatches:
<img width="653" height="179" alt="image" src="https://github.com/user-attachments/assets/dc648b55-6408-4d80-af4a-44e288f15ebe" />
```html
<span class="mtk8">public</span>
<span class="mtk1 dyn-rule-5-0 colorpicker-color-decoration">&nbsp;</span>
<span class="mtk1 dyn-rule-5-0 colorpicker-color-decoration">&nbsp;</span>
<span class="mtk1 dyn-rule-5-0 colorpicker-color-decoration">&nbsp;</span>
```

Two independent defects, each verified in a real browser before and after.

## 1. `model.findMatches` was called with shifted arguments

`InvokeScriptAsync(method, args)` emits `method(element, ...args)` so the host can resolve the editor element. That is correct for the `ts-helpermethods` functions — they all take the element first — but wrong for a Monaco API, and `ModelHelper` pointed it at `model.findMatches`. Every argument shifted one slot right:

| Monaco parameter | Received | Effect |
|---|---|---|
| `searchString` | the `<div>` | `new RegExp(String(div))` → `/[object HTMLDivElement]/`, a character class that includes a space |
| `wordSeparators` | `true` | `true.length` is `undefined` → empty separator table, so only whitespace-bounded single chars are valid matches |
| `captureMatches` | `null` | `matches: null` on every hit |
| `limitResultCount` | `true` | `result.length < true` → stops after one match |

The first valid match in `public class Program {` is the space at index 6 → column 7. The sample app's `ColorProvider` searches for `#[A-Fa-f0-9]{8}`, which occurs nowhere in `Content.txt`, but got back one bogus match with `matches: null`, fell through to its `?? Colors.Black` default, and handed Monaco a black `ColorInformation` at 1:7–1:8.

Measured against the unfixed build:

```
findMatches as called by C# → [{"range":{"startLineNumber":1,"startColumn":7,"endLineNumber":1,"endColumn":8},"matches":null}]
findMatches with correct args → []
```

Fixed by building the `findMatches` / `findNextMatch` / `findPreviousMatch` scripts explicitly and sending them with `SendScriptAsync`, which does not prepend the element. This matches how the rest of `ModelHelper` already works.

## 2. Provider registrations leaked across editor instances

Providers register on the page-global `monaco.languages` registry, and Monaco concatenates the results of all of them. On WASM every editor shares one document and one Monaco module, so each new editor added another document-color provider reporting the same range — hence one extra swatch per instance. Desktop hid this because each editor owns its own WebView.

Measured against the unfixed build: **4 managed round-trips per color computation** after 3 extra registrations.

`registerHoverProvider` already kept one registration per language; color, completion, code-action and code-lens did not. All five now share `registerSingleProvider`, and provider callbacks route to the owning editor via the model they are handed, so a single registration serves every editor on the page.

## Behaviour changes worth flagging

- Completion `triggerCharacters` is now **last-writer-wins** across editors on a WASM page. Previously N duplicated providers each kept their own — both are wrong, this one is less wrong, and it also fixes duplicated completion items on the 2nd+ editor.
- `resolveCompletionItem` routes to the model from the most recent `provideCompletionItems` call rather than the registering editor. A heuristic, but necessary once there is one shared registration, and correct in every realistic flow.
- `FindMatchesAsync` returns `[]` instead of `null` on failure, and JS errors surface via `CodeEditor.InternalException` instead of being swallowed. The former removes a latent NRE in exactly the sample-app path that produced this bug.
- Removed a leftover `Console.WriteLine("Register color provider: …")` that printed on every editor load.

## Not fixed here

`DetectIndentationAsync` is the one remaining shifted call site, left deliberately. It also calls a `detectIndentationAsync` that does not exist on Monaco, so today it is a silent no-op; its public signature takes `bool defaultTabSize` where Monaco wants a number, so making the call actually land would set tab size to 1 — a regression from doing nothing. It needs a signature fix, which is a separate breaking change.

## Testing

- `ModelHelperScriptTests` (new, 6 tests) pins the emitted argument order, and — since this is the first path where a caller-supplied pattern actually reaches Monaco intact — that the pattern survives as a JS string literal (LF, U+2028 and U+2029 escaped; quotes and backslashes round-trip).
- `WasmIntegrationTests` (2 new Playwright tests): one evaluates the real generated script against the real model and asserts `[]`; the other asserts exactly one managed round-trip per color computation after four registrations.
- 288/288 tests pass locally. Solution, WASM app and desktop app all build clean.
- DesktopCDP tests were not run locally (they need a Release desktop build driving WebView2). The desktop target compiles and the bundle is copied to `DesktopContent`; the dedupe is a no-op there since each editor owns its WebView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
