### PR TITLE
test: gate integration tests on real app readiness

### DIFF
--- a/MonacoEditorComponent.Tests/DesktopAppFixture.cs
+++ b/MonacoEditorComponent.Tests/DesktopAppFixture.cs
@@ -70,6 +70,13 @@ public sealed class DesktopAppFixture : IAsyncLifetime
     /// <summary>The Playwright browser context for tracing support.</summary>
     public IBrowserContext Context { get; private set; } = null!;
 
+    /// <summary>
+    /// The editor text the app settled on during its own initialisation, captured once before any
+    /// test ran. Tests asserting on first-load content must use this rather than reading the live
+    /// model, which every preceding test in the collection is free to overwrite.
+    /// </summary>
+    public string InitialEditorText { get; private set; } = string.Empty;
+
     public async ValueTask InitializeAsync()
     {
         // 0. Create Playwright instance (owned by this fixture).
@@ -173,6 +180,20 @@ public sealed class DesktopAppFixture : IAsyncLifetime
         // registration, language registration, markers, decorations, theme switching).
         // The harness emits TEST_HARNESS_READY as its final stdout marker.
         await WaitForLogLineAfterAsync(0, @"TEST_HARNESS_READY", MonacoReadyTimeoutMs);
+
+        // 11. Wait for the app to finish initialising altogether.
+        //
+        // TEST_HARNESS_READY only covers Editor_Loaded. Editor_Loading runs as a second,
+        // independent async void chain that fetches Content.txt and pushes it into the model,
+        // and nothing orders the two -- so the harness can report ready while a Content.txt
+        // write is still in flight, ready to overwrite whatever the first test writes.
+        // APP_INIT_SETTLED is emitted only once both chains are done and the app has read the
+        // model back, which cannot happen before their writes have landed.
+        await WaitForLogLineAfterAsync(0, @"APP_INIT_SETTLED", MonacoReadyTimeoutMs);
+
+        // 12. Snapshot the settled content for tests that assert on first-load state.
+        InitialEditorText = await Page.EvaluateAsync<string>(
+            "() => monaco.editor.getEditors()[0].getValue()");
     }
 
     public async ValueTask DisposeAsync()

--- a/MonacoEditorComponent.Tests/DesktopBridgeIntegrationTests.cs
+++ b/MonacoEditorComponent.Tests/DesktopBridgeIntegrationTests.cs
@@ -926,17 +926,11 @@ public sealed class DesktopBridgeIntegrationTests : IAsyncLifetime
         _currentTestName = nameof(TextContent_NonEmptyOnFirstLoad);
         try
         {
-            // The editor should have non-empty text from the initial state push.
-            // Wait for Monaco to have text content.
-            await _fixture.Page.WaitForFunctionAsync(
-                "() => monaco.editor.getEditors()[0].getValue().length > 0",
-                null, new PageWaitForFunctionOptions { Timeout = 10_000 });
-
-            var text = await _fixture.Page.EvaluateAsync<string>(
-                "() => monaco.editor.getEditors()[0].getValue()");
-
-            Assert.NotNull(text);
-            Assert.NotEmpty(text);
+            // Asserted against the fixture's snapshot, not the live model: "first load" is a
+            // property of app startup, and by the time this test runs any other test in the
+            // collection may already have replaced the content.
+            Assert.NotNull(_fixture.InitialEditorText);
+            Assert.NotEmpty(_fixture.InitialEditorText);
         }
         catch
         {

--- a/MonacoEditorComponent.Tests/DesktopIntegrationTests.cs
+++ b/MonacoEditorComponent.Tests/DesktopIntegrationTests.cs
@@ -34,10 +34,14 @@ public sealed class DesktopIntegrationTests : IAsyncLifetime
         _fixture = fixture;
     }
 
-    public ValueTask InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _testFailed = false;
-        return ValueTask.CompletedTask;
+
+        // The collection shares one app process and page, and xUnit does not fix the order tests
+        // run in, so every test starts from a state some other test left behind unless it is
+        // reset here. DesktopBridgeIntegrationTests already resets per test; this class did not.
+        await _fixture.ResetEditorStateAsync();
     }
 
     public async ValueTask DisposeAsync()
@@ -539,22 +543,32 @@ public sealed class DesktopIntegrationTests : IAsyncLifetime
 
             Assert.Equal("second editor", secondText);
             Assert.NotEqual(firstText, secondText);
-
-            // Cleanup: dispose the second editor and remove its container.
-            await _fixture.Page.EvaluateAsync("""
-                () => {
-                    const editors = monaco.editor.getEditors();
-                    const last = editors[editors.length - 1];
-                    last.dispose();
-                    const el = document.getElementById('test-editor-2');
-                    if (el) el.remove();
-                }
-                """);
         }
         catch
         {
             _testFailed = true;
             throw;
+        }
+        finally
+        {
+            // Must run even when an assertion above failed: PresenterLifecycle_SingleEditorInstance
+            // asserts the editor count is exactly 1, so a leaked second instance turns one failure
+            // here into a cascade across the rest of the collection.
+            try
+            {
+                await _fixture.Page.EvaluateAsync("""
+                    () => {
+                        const el = document.getElementById('test-editor-2');
+                        for (const editor of monaco.editor.getEditors()) {
+                            if (el && el.contains(editor.getContainerDomNode())) {
+                                editor.dispose();
+                            }
+                        }
+                        if (el) el.remove();
+                    }
+                    """);
+            }
+            catch { /* best-effort cleanup */ }
         }
     }
 

--- a/MonacoEditorComponent.Tests/DesktopIntegrationTests.cs
+++ b/MonacoEditorComponent.Tests/DesktopIntegrationTests.cs
@@ -656,8 +656,12 @@ public sealed class DesktopIntegrationTests : IAsyncLifetime
         _currentTestName = nameof(PresenterLifecycle_InitCompleteOnce);
         try
         {
+            // Matched at the end of the line, not anywhere in it: "INIT_COMPLETE" is a substring
+            // of INIT_COMPLETE_PROBE, the marker CodeEditor.Events emits when it gives up waiting
+            // for the callback -- a Contains match counts that too.
             var lines = _fixture.GetLinesAfter(0);
-            var initCompleteCount = lines.Count(l => l.Contains("INIT_COMPLETE"));
+            var initCompleteCount = lines.Count(
+                l => l.TrimEnd().EndsWith("INIT_COMPLETE", StringComparison.Ordinal));
 
             Assert.Equal(1, initCompleteCount);
         }

--- a/MonacoEditorComponent.Tests/WasmAppFixture.cs
+++ b/MonacoEditorComponent.Tests/WasmAppFixture.cs
@@ -24,17 +24,39 @@ public sealed class WasmAppFixture : IAsyncLifetime
 {
     private const int MonacoReadyTimeoutMs = 30_000;
 
+    /// <summary>
+    /// Emitted by <c>EditorControl</c> once both of its <c>async void</c> init handlers have
+    /// finished and the last write it issued has been observed landing in Monaco.
+    /// </summary>
+    private const string AppInitSettledMarker = "APP_INIT_SETTLED";
+
+    /// <summary>Content every test starts from -- see <see cref="ResetEditorStateAsync"/>.</summary>
+    private const string ResetText = "// test-init-text";
+
     private IPlaywright? _playwright;
     private Process? _serverProcess;
     private IBrowser? _browser;
     private string _processLogPath = string.Empty;
     private int _serverPort;
 
+    private readonly List<string> _consoleLines = [];
+    private readonly object _consoleLock = new();
+
+    private readonly TaskCompletionSource<string> _appInitComplete =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
     /// <summary>The Playwright page connected to the WASM app.</summary>
     public IPage Page { get; private set; } = null!;
 
     /// <summary>The Playwright browser context for tracing support.</summary>
     public IBrowserContext Context { get; private set; } = null!;
+
+    /// <summary>
+    /// The editor text the app settled on during its own initialisation, captured once before any
+    /// test ran. Tests asserting on first-load content must use this rather than reading the live
+    /// model, which every preceding test in the collection is free to overwrite.
+    /// </summary>
+    public string InitialEditorText { get; private set; } = string.Empty;
 
     public async ValueTask InitializeAsync()
     {
@@ -80,21 +102,127 @@ public sealed class WasmAppFixture : IAsyncLifetime
 
         Page = await Context.NewPageAsync();
 
-        // 8. Navigate to the WASM app.
+        // 8. Start capturing console output BEFORE navigating. C# Console.WriteLine surfaces
+        // here under WASM, and the readiness marker is emitted during boot -- subscribing after
+        // GotoAsync would race it.
+        Page.Console += OnPageConsole;
+
+        // 9. Navigate to the WASM app.
         await Page.GotoAsync($"http://localhost:{_serverPort}/", new()
         {
             WaitUntil = WaitUntilState.NetworkIdle,
             Timeout = MonacoReadyTimeoutMs,
         });
 
-        // 9. Wait for Monaco to be ready.
+        // 10. Wait for a Monaco instance to exist.
         await Page.WaitForFunctionAsync(
             "() => typeof monaco !== 'undefined' && monaco.editor.getEditors().length > 0",
             null, new PageWaitForFunctionOptions { Timeout = MonacoReadyTimeoutMs });
+
+        // 11. Wait for the app to finish its own initialisation.
+        //
+        // The step above is NOT sufficient on its own: it goes green the moment the editor is
+        // constructed, while EditorControl.Editor_Loading is still fetching Content.txt and
+        // pushing it into the model. Tests that start in that window get their writes clobbered
+        // by the late push -- observed on CI run 32854772712, where setValue landed at t+9.13s
+        // and the following getValue at t+9.29s returned Content.txt instead.
+        await WaitForAppInitCompleteAsync();
+
+        // 12. Snapshot the settled content for tests that assert on first-load state.
+        InitialEditorText = await Page.EvaluateAsync<string>(
+            "() => monaco.editor.getEditors()[0].getValue()");
+    }
+
+    private void OnPageConsole(object? sender, IConsoleMessage message)
+    {
+        var text = message.Text ?? string.Empty;
+
+        lock (_consoleLock)
+        {
+            _consoleLines.Add($"[{message.Type}] {text}");
+        }
+
+        if (text.Contains(AppInitSettledMarker, StringComparison.Ordinal))
+        {
+            _appInitComplete.TrySetResult(text);
+        }
+    }
+
+    /// <summary>
+    /// Blocks until the app emits its init-complete marker, failing with the captured console
+    /// output rather than a bare timeout when it never arrives.
+    /// </summary>
+    private async Task WaitForAppInitCompleteAsync()
+    {
+        using var timeoutCts = new CancellationTokenSource();
+
+        var completed = await Task.WhenAny(
+            _appInitComplete.Task,
+            Task.Delay(MonacoReadyTimeoutMs, timeoutCts.Token));
+
+        // Release the timer as soon as the marker wins, rather than leaving it armed for the
+        // rest of the timeout on every run.
+        await timeoutCts.CancelAsync();
+
+        if (completed != _appInitComplete.Task)
+        {
+            throw new TimeoutException(
+                $"The app did not emit '{AppInitSettledMarker}' within {MonacoReadyTimeoutMs}ms. " +
+                "Tests cannot start before it without racing the app's initial text push.\n" +
+                "Console output so far:\n  " + string.Join("\n  ", GetConsoleLines()));
+        }
+
+        var marker = await _appInitComplete.Task;
+
+        if (marker.Contains($"{AppInitSettledMarker}:error=", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"The app reported a failure while initialising: {marker}");
+        }
+    }
+
+    /// <summary>Console output captured from the page since navigation.</summary>
+    public IReadOnlyList<string> GetConsoleLines()
+    {
+        lock (_consoleLock)
+        {
+            return [.. _consoleLines];
+        }
+    }
+
+    /// <summary>
+    /// Returns the editor to a known state so tests in the shared collection do not inherit each
+    /// other's mutations. Mirrors <c>DesktopAppFixture.ResetEditorStateAsync</c>.
+    /// </summary>
+    public async Task ResetEditorStateAsync()
+    {
+        await Page.EvaluateAsync($$"""
+            () => {
+                const editor = monaco.editor.getEditors()[0];
+                editor.setValue('{{ResetText}}');
+                const model = editor.getModel();
+                if (model) {
+                    monaco.editor.setModelLanguage(model, 'javascript');
+                    monaco.editor.setModelMarkers(model, 'test', []);
+                    monaco.editor.setModelMarkers(model, 'CodeEditor', []);
+                    editor.deltaDecorations(
+                        model.getAllDecorations().map(d => d.id),
+                        []
+                    );
+                }
+                monaco.editor.setTheme('vs');
+                editor.updateOptions({ readOnly: false });
+            }
+            """);
     }
 
     public async ValueTask DisposeAsync()
     {
+        if (Page is not null)
+        {
+            Page.Console -= OnPageConsole;
+        }
+
         if (_browser is not null)
         {
             try { await _browser.CloseAsync(); } catch { /* best-effort */ }
@@ -156,6 +284,16 @@ public sealed class WasmAppFixture : IAsyncLifetime
             }
             catch { /* best-effort */ }
         }
+
+        try
+        {
+            // The page console carries the app's own markers, so a failure here can be read
+            // against what the app had actually done by that point.
+            await File.WriteAllLinesAsync(
+                Path.Combine(artifactsDir, $"{testName}-console.log"),
+                GetConsoleLines());
+        }
+        catch { /* best-effort */ }
     }
 
     private static string ResolveWasmBuildOutput(string repoRoot)

--- a/MonacoEditorComponent.Tests/WasmIntegrationTests.cs
+++ b/MonacoEditorComponent.Tests/WasmIntegrationTests.cs
@@ -29,10 +29,13 @@ public sealed class WasmIntegrationTests : IAsyncLifetime
         _fixture = fixture;
     }
 
-    public ValueTask InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _testFailed = false;
-        return ValueTask.CompletedTask;
+
+        // The collection shares one page, and xUnit does not fix the order tests run in, so
+        // every test starts from a state some other test left behind unless it is reset here.
+        await _fixture.ResetEditorStateAsync();
     }
 
     public async ValueTask DisposeAsync()
@@ -40,6 +43,31 @@ public sealed class WasmIntegrationTests : IAsyncLifetime
         if (_testFailed)
         {
             await _fixture.CaptureFailureArtifacts(_currentTestName);
+        }
+    }
+
+    /// <summary>
+    /// Regression guard for the fixture's readiness contract. Before the app emitted
+    /// <c>APP_INIT_SETTLED</c>, the fixture released tests as soon as a Monaco instance existed,
+    /// while <c>EditorControl.Editor_Loading</c> was still fetching Content.txt and pushing it
+    /// into the model. A test writing in that window had its write overwritten -- CI run
+    /// 32854772712 failed exactly that way. If the gate regresses, the app's text has not landed
+    /// by the time this runs and the snapshot is empty or wrong.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "WasmPlaywright")]
+    public void AppInitialisation_TextHasLandedBeforeTestsRun()
+    {
+        _currentTestName = nameof(AppInitialisation_TextHasLandedBeforeTestsRun);
+        try
+        {
+            // Contains rather than StartsWith: Content.txt carries a UTF-8 BOM.
+            Assert.Contains("public class Program", _fixture.InitialEditorText);
+        }
+        catch
+        {
+            _testFailed = true;
+            throw;
         }
     }
 

--- a/MonacoEditorComponent/CodeEditor/CodeEditor.Events.cs
+++ b/MonacoEditorComponent/CodeEditor/CodeEditor.Events.cs
@@ -52,6 +52,12 @@ namespace Monaco
 
         private IThemeListener? _themeListener;
         private EditorLifecycleState _lifecycleState = EditorLifecycleState.Unloaded;
+
+        /// <summary>
+        /// Set while <see cref="CodeEditorLoaded"/> is running, so a second invocation cannot
+        /// re-run initialisation before the first has published its state.
+        /// </summary>
+        private bool _codeEditorLoadedInFlight;
         private int _desktopInitTimeoutRetryCount;
 
         /// <summary>
@@ -735,6 +741,21 @@ namespace Monaco
                 return;
             }
 
+            // Re-entrancy guard. The guard above is not enough on its own: this method is
+            // async void, and the state it tests (_lifecycleState, _desktopBootstrapInFlight)
+            // is only updated after the awaits below. The desktop init probe polls exactly that
+            // state, so while a first call is mid-await the probe still reads "Loading with
+            // bootstrap in flight", concludes the callback never arrived, and synthesizes a
+            // second CodeEditorLoaded -- running the whole init sequence twice. Both callers
+            // are on the UI thread, so a plain flag is sufficient.
+            if (_codeEditorLoadedInFlight)
+            {
+                Debug.WriteLine("CodeEditorLoaded: ignoring (already in flight)");
+                return;
+            }
+
+            _codeEditorLoadedInFlight = true;
+
             try
             {
                 _view = _view ?? throw new InvalidOperationException("The view not set");
@@ -745,7 +766,12 @@ namespace Monaco
                 _initialized = true;
 
                 // Emit canonical init-complete marker for diagnostics (always visible).
-                Debug.WriteLine("INIT_COMPLETE");
+                // Debug.WriteLine is [Conditional("DEBUG")], so under -c Release -- which is how
+                // CI and the integration fixtures run the app -- this marker was compiled away
+                // entirely, leaving PresenterLifecycle_InitCompleteOnce counting the unrelated
+                // INIT_COMPLETE_PROBE line instead. DiagnosticLog honours the same
+                // MONACO_DIAGNOSTICS gate as every other marker the tests read, in every config.
+                DesktopCodeEditorPresenter.DiagnosticLog("INIT_COMPLETE");
 
                 // Layout first to ensure the editor dimensions are correct.
                 await SendScriptAsync("EditorContext.getEditorForElement(element).editor.layout();");
@@ -788,6 +814,10 @@ namespace Monaco
                 _desktopBootstrapInFlight = false;
                 Debug.WriteLine($"CodeEditorLoaded failed: {ex}");
                 InternalException?.Invoke(this, ex);
+            }
+            finally
+            {
+                _codeEditorLoadedInFlight = false;
             }
         }
 

--- a/MonacoEditorTestApp/EditorControl.xaml.cs
+++ b/MonacoEditorTestApp/EditorControl.xaml.cs
@@ -36,6 +36,40 @@ namespace MonacoEditorTestApp
 
         private ContextKey? _myCondition;
 
+        #region App readiness signalling
+        /// <summary>
+        /// Completed when <see cref="Editor_Loading"/> has run to the end, successfully or not.
+        /// </summary>
+        private readonly TaskCompletionSource _loadingHandlerCompleted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>
+        /// Completed when <see cref="Editor_Loaded"/> has run to the end, successfully or not.
+        /// </summary>
+        private readonly TaskCompletionSource _loadedHandlerCompleted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Guards <see cref="SignalAppReadyWhenInitCompletesAsync"/> against a second start.</summary>
+        private int _appReadySignalStarted;
+
+        /// <summary>
+        /// Final marker written to stdout (the browser console under WASM) once every async
+        /// initialisation path this control owns has finished AND the last write it issued has
+        /// been observed landing in Monaco.
+        /// </summary>
+        /// <remarks>
+        /// Integration fixtures gate on this. <c>TEST_HARNESS_READY</c> cannot serve that purpose:
+        /// it is emitted from <see cref="Editor_Loaded"/> only when <c>MONACO_DIAGNOSTICS=1</c>
+        /// (so never under WASM), and it proves the harness assigned <c>Editor.Text</c> -- not that
+        /// the assignment reached the model, nor that the independent <see cref="Editor_Loading"/>
+        /// chain, which pushes Content.txt, has finished. Both handlers are <c>async void</c>, so
+        /// neither the control nor the component awaits them and their completion order is
+        /// undefined. Tests that start before this marker race a late text push and read back the
+        /// wrong content.
+        /// </remarks>
+        public const string AppInitSettledMarker = "APP_INIT_SETTLED";
+        #endregion
+
         #region CSS Style Objects
         private readonly CssLineStyle CssLineDarkRed = new()
         {
@@ -81,6 +115,52 @@ namespace MonacoEditorTestApp
 
             Editor.InternalException += Editor_InternalException;
             Editor.PropertyChanged += Editor_PropertyChanged;
+
+            SignalAppReadyWhenInitCompletes();
+        }
+
+        /// <summary>
+        /// Starts the one-shot task that emits <see cref="AppInitSettledMarker"/>. Safe to call
+        /// more than once; only the first call starts anything.
+        /// </summary>
+        private void SignalAppReadyWhenInitCompletes()
+        {
+            if (Interlocked.Exchange(ref _appReadySignalStarted, 1) == 0)
+            {
+                _ = SignalAppReadyWhenInitCompletesAsync();
+            }
+        }
+
+        private async Task SignalAppReadyWhenInitCompletesAsync()
+        {
+            try
+            {
+                // Both handlers are async void, so this is the only place their completion is
+                // joined. Either may finish first.
+                await Task.WhenAll(_loadingHandlerCompleted.Task, _loadedHandlerCompleted.Task);
+
+                // Every text write above was issued but not necessarily observed landing. Reading
+                // the value back is a round-trip on the same ordered channel those writes used, so
+                // it cannot complete before they have been applied -- the marker then means the
+                // model has stopped changing on the app's account, not merely that the app stopped
+                // asking it to change.
+                //
+                // Deliberately not Editor.GetModel(): that returns the cached ModelHelper, which is
+                // only assigned on a later Loaded pass and was still null here on desktop, so it
+                // reported no length and drained nothing.
+                var settled = Editor is null
+                    ? null
+                    : await Editor.InvokeScriptAsync(
+                        "(() => { const e = monaco.editor.getEditors()[0]; return e ? e.getValue().length : -1; })()");
+
+                Console.WriteLine($"{AppInitSettledMarker}:length={settled ?? "unavailable"}");
+            }
+            catch (Exception ex)
+            {
+                // Emit the marker regardless: a fixture blocked on it would otherwise sit until its
+                // own timeout with nothing explaining why.
+                Console.WriteLine($"{AppInitSettledMarker}:error={ex.GetType().Name}:{ex.Message}");
+            }
         }
 
         private void Editor_Unloaded(object sender, RoutedEventArgs e)
@@ -103,6 +183,7 @@ namespace MonacoEditorTestApp
         {
             if (Editor is null)
             {
+                _loadingHandlerCompleted.TrySetResult();
                 return;
             }
 
@@ -231,9 +312,27 @@ namespace MonacoEditorTestApp
             {
                 Debug.WriteLine($"Editor_Loading failed: {ex}");
             }
+            finally
+            {
+                _loadingHandlerCompleted.TrySetResult();
+            }
         }
 
         private async void Editor_Loaded(object sender, RoutedEventArgs e)
+        {
+            // Body split out so the readiness signal fires on every exit path, including the
+            // MONACO_DIAGNOSTICS early return that the WASM run always takes.
+            try
+            {
+                await Editor_LoadedCoreAsync();
+            }
+            finally
+            {
+                _loadedHandlerCompleted.TrySetResult();
+            }
+        }
+
+        private async Task Editor_LoadedCoreAsync()
         {
             // Populated here rather than in Editor_Loading: script calls are gated on the
             // editor being initialized, which only happens once loading completes. Not


### PR DESCRIPTION
Fixes the `WasmIntegrationTests.BasicTextEditing_SetAndGetText` failure that turned main red on [run 32854772712](https://github.com/unoplatform/uno.monaco.editor/actions/runs/32854772712), and the same class of problem in the peer fixtures.

## Root cause

`WasmAppFixture` released tests as soon as `monaco.editor.getEditors()` was non-empty. `EditorControl.Editor_Loading` is `async void`, so nothing awaits it — it was still fetching `Content.txt` and pushing it into the model while tests ran.

From the failing run's Playwright trace (times from `newPage`):

| t | event |
|---|---|
| 7.551s | `waitForFunction` resolves — fixture declares ready |
| 7.782s → 9.033s | **all five tests run to completion** |
| 9.130s | `setValue('WASM Playwright test 4fa9c1…')` returns |
| **9.185s** | console: `Register color provider: csharp/01E34BFA` — app init still running |
| 9.294s | `getValue()` returns `public class Program { // http://www.github.com/…` |

So every WASM test was running inside the app's init window; it only went red when a write happened to land inside one test's write→read gap. Not a regression from #47 — the identical tree passed on that PR's own run.

Disabling the new gate locally reproduces it deterministically: the model is observably **empty** (`String: ""`) at the moment the old check went green.

## Changes

**`test: gate integration tests on real app readiness`**

- `EditorControl` joins both `async void` init handlers and reads the value back through the editor before writing `APP_INIT_SETTLED`. The read is a round-trip on the same channel the writes used, so the marker means the model has stopped changing on the app's account — not merely that the app stopped asking. Verified `length=478` (Content.txt, CRLF) on WASM, `length=17` (`// test-init-text`) on desktop.
- Both fixtures gate on it and snapshot `InitialEditorText`. `TEST_HARNESS_READY` could not serve: it covers only `Editor_Loaded`, and is emitted solely under `MONACO_DIAGNOSTICS=1` — never under WASM.
- `ResetEditorStateAsync` added to `WasmAppFixture` and called per test in both `WasmIntegrationTests` and `DesktopIntegrationTests`, which never reset at all. xUnit does not fix test order.
- `MultiInstance_EditorsHaveIndependentState` disposes its second editor in a `finally` — a failed assertion previously leaked an editor and cascaded into `PresenterLifecycle_SingleEditorInstance`.
- `TextContent_NonEmptyOnFirstLoad` asserts on the snapshot; read live it merely observed whichever test ran last.
- New `AppInitialisation_TextHasLandedBeforeTestsRun` guards the gate itself; the WASM fixture now dumps page console output with its failure artifacts.

**`fix(editor): stop duplicate CodeEditorLoaded init`** — two pre-existing defects this surfaced:

- `INIT_COMPLETE` used `Debug.WriteLine`, which is `[Conditional("DEBUG")]` and compiled out under `-c Release` — how CI runs the app. `PresenterLifecycle_InitCompleteOnce` was matching the only surviving line, `INIT_COMPLETE_PROBE`, and so passed precisely when the callback it asserts about had *not* arrived.
- With the marker visible, it appeared **twice** per desktop run. `CodeEditorLoaded` is `async void` and the state its entry guard tests is only updated after its awaits, so the init probe reads "Loading with bootstrap in flight" mid-flight and synthesizes a second call — running layout, initial property application and focus handling twice. Added a narrow re-entrancy flag; `CodeEditor_Loaded` (the XAML handler) and its "2nd time around" `_model` assignment are untouched.

## Verification

Full suite green **8/8 consecutive runs** on Windows — 321 tests, including 40 DesktopCDP and 6 WasmPlaywright. Desktop log goes from two `INIT_COMPLETE` lines to one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)