### PR TITLE
ci: unshallow clone in copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,6 +31,16 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # Copilot code review overrides the checkout above with `fetch-depth: 2`, which
+      # leaves Nerdbank.GitVersioning unable to walk back to the version-height-resetting
+      # commit. NB.GV is a GlobalPackageReference, so a shallow clone breaks `nbgv cloud`
+      # below *and* every subsequent build. No-op for the coding agent, which gets depth 0.
+      - name: Deepen shallow checkout
+        run: |
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --unshallow --tags
+          fi
+
       - uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json


### PR DESCRIPTION
## Problem

Copilot code review has been failing its setup steps on every PR since ~2026-08-22 with a `ccr-setup-step-failure` comment ([example](https://github.com/unoplatform/uno.monaco.editor/pull/45#issuecomment-5413375372)):

```text
Nerdbank.GitVersioning.GitException: Shallow clone lacks the objects
required to calculate version height.
 ---> An commit object with SHA ac424efb… could not be found.
```

Nothing in the repo changed — `copilot-setup-steps.yml` was untouched since 2025-11-05. What changed is on GitHub's side: **Copilot code review didn't run setup steps at all until ~2026-08-22.** Review jobs from Aug 4–5 have zero `User Configured Setup Step` entries and passed; every run from Aug 22 onward has them and fails.

When it does run them, the harness overrides the checkout inputs:

| `copilot-setup-steps.yml` | what actually ran |
|---|---|
| `fetch-depth: 0` | `fetch-depth: 2` |
| `fetch-tags: true` | `fetch-tags: true` (survived) |
| (checkout default `persist-credentials: true`) | `persist-credentials: false` (injected) |

Two commits is not enough history for `./nbgv cloud -c -a`, the step aborts, and `dotnet restore` never runs — so the reviewer works in an unrestored tree.

Impact is degraded review context, not a blocked review: Copilot still posts. Regular CI is unaffected, since `ci.yml` gets its real `fetch-depth: 0`.

## Fix

Deepen the clone when it's shallow, before anything that needs history.

The alternative — giving code review its own lean `.github/workflows/copilot-code-review.yml` without nbgv — doesn't work here: `Nerdbank.GitVersioning` is a `GlobalPackageReference` in `Directory.Packages.props`, so a shallow clone breaks *every* build in the repo, not just the nbgv CLI call. And dropping nbgv from the shared file would break the Copilot coding agent, which does get `fetch-depth: 0` and does need the workloads + restore.

The guard is a no-op on a complete clone, so the coding agent path is unchanged. History is small (654 commits, 17 MB pack), so deepening costs seconds.

## ⚠️ This PR cannot verify itself

I requested a Copilot review on this branch to test the fix. It failed again — **and the new step never ran.** The job's step list contains only the three setup steps from `main`'s copy of the file:

```
✓ Checkout code
✓ Run actions/setup-dotnet@v5
X Run {          <-- still "Shallow clone lacks the objects…"
```

No `Deepen shallow checkout`, even though the run's `head_sha` is this branch's commit and the branch demonstrably contains the step.

**Copilot code review resolves `copilot-setup-steps.yml` from the default branch, not from the PR head** — the expected security posture, since a PR must not be able to inject steps into a privileged review run. So this fix is only testable once it is on `main`. Neither the `push`/`pull_request` validation runs nor a Copilot review on this branch can prove it, and a red Copilot check here is expected, not evidence against the fix.

## What is verified

Reproduced the harness's exact post-fix conditions locally — anonymous depth-2 clone with no credentials configured (`GIT_CONFIG_GLOBAL=/dev/null`, `GIT_TERMINAL_PROMPT=0`), matching the injected `persist-credentials: false`:

```
shallow before: true   commits: 3
shallow after:  false  commits: 654  tags: 8
$ ./nbgv get-version -v SemVer2
6.5.0-dev.348
```

So the anonymous unshallow succeeds without credentials, and nbgv computes the version height afterwards — the exact operation that fails in the harness today. The guard is also load-bearing: a bare `git fetch --unshallow` errors on a complete repo.

## After merge

Re-request a Copilot review on any open PR and confirm the step list shows `Deepen shallow checkout`, and that no `ccr-setup-step-failure` comment follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
