### PR TITLE
fix(tests): probe each static server candidate to readiness

### DIFF
--- a/.flow/memory/pitfalls.md
+++ b/.flow/memory/pitfalls.md
@@ -65,7 +65,7 @@ Use Channel.CreateBounded (not Unbounded) for inbound message queues from untrus
 Playwright NuGet build/buildTransitive targets conflict with UseArtifactsOutput+OutputType=Exe on macOS/Linux; exclude those assets and install browsers from NuGet cache path instead
 
 ## 2026-02-11 manual [pitfall]
-When starting external processes with fallback candidates, verify the process survives briefly (check HasExited after short delay) before returning -- commands like 'dotnet serve' can start then exit immediately if a tool is not installed
+When starting external processes with fallback candidates, probe each one all the way to the readiness signal you actually need (an HTTP response, a CDP handshake) and reject it the moment its process exits -- a 'survives briefly' liveness check races the child's startup and accepts doomed candidates ('dotnet serve' with dotnet-serve uninstalled took >500ms to exit 1 on CI run 33770173883, blocking main)
 
 ## 2026-02-11 manual [pitfall]
 When polling for external service readiness (HTTP server, CDP endpoint), always check whether the backing process has died between polls -- otherwise timeout gives a generic error instead of a fast diagnostic with process exit code and stderr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,9 +228,11 @@ jobs:
           playwright-version: ${{ env.PLAYWRIGHT_VERSION }}
 
       # WASM Playwright tests are already covered by the ubuntu job.
-      # macOS ARM validates builds + unit tests; exclude DesktopCDP (headless) and WasmPlaywright (slow startup on ARM).
+      # macOS ARM validates builds + unit tests; exclude DesktopCDP (headless), WasmPlaywright and
+      # StaticServer -- a python http.server on this runner accepts the connection and then never
+      # answers, which is the same thing that keeps the WASM suite off this job.
       - name: Run tests
-        run: dotnet test --project MonacoEditorComponent.Tests/MonacoEditorComponent.Tests.csproj -c Release -p:ArtifactsPath="${{ env.ARTIFACTS_PATH }}" --no-build --coverage --coverage-output-format cobertura --results-directory ${{ runner.temp }}/TestResults -- --filter-not-trait "Category=DesktopCDP" --filter-not-trait "Category=WasmPlaywright" --report-xunit --report-xunit-filename test-results.xml
+        run: dotnet test --project MonacoEditorComponent.Tests/MonacoEditorComponent.Tests.csproj -c Release -p:ArtifactsPath="${{ env.ARTIFACTS_PATH }}" --no-build --coverage --coverage-output-format cobertura --results-directory ${{ runner.temp }}/TestResults -- --filter-not-trait "Category=DesktopCDP" --filter-not-trait "Category=WasmPlaywright" --filter-not-trait "Category=StaticServer" --report-xunit --report-xunit-filename test-results.xml
 
       - name: Upload test artifacts
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,8 @@ Additional jobs (Sign, Publish Dev, Publish Production) run only on pushes to `m
 ### Known CI limitations
 
 - **Desktop CDP tests** run on the Windows CI runner (`windows-latest`), which has WebView2 Runtime and Edge pre-installed. They are excluded from Ubuntu (no WebView2) and macOS ARM (no WebView2 on macOS). The fixture uses `-c Release --no-build` to avoid rebuild overhead and a 60s Monaco readiness timeout to accommodate CI cold-start latency.
-- **WASM Playwright tests** are excluded from the Windows Desktop Tests job and the macOS ARM job (`--filter-not-trait "Category=WasmPlaywright"`). Ubuntu covers WASM Playwright tests; macOS ARM validates builds and unit tests only (the static file server startup is too slow on ARM runners).
+- **WASM Playwright tests** are excluded from the Windows Desktop Tests job and the macOS ARM job (`--filter-not-trait "Category=WasmPlaywright"`). Ubuntu covers WASM Playwright tests; macOS ARM validates builds and unit tests only (the static file server does not work on that runner -- see below).
+- **Static file server tests** (`Category=StaticServer`, the `WasmAppFixture` candidate fall-through) run on Ubuntu and Windows but are excluded from macOS ARM. A `python -m http.server` started there accepts the connection and then never answers: it prints nothing even with `-u`, and probes time out rather than being refused, so it hangs somewhere before it serves. Cold startup on the Windows runner is also slow -- over 5s to first answer -- which is why every candidate gets a 30s readiness budget.
 
 ### How to verify
 

--- a/MonacoEditorComponent.Tests/StaticServerFallbackTests.cs
+++ b/MonacoEditorComponent.Tests/StaticServerFallbackTests.cs
@@ -15,6 +15,11 @@ namespace MonacoEditorComponent.Tests;
 /// exit 1, the doomed process was returned as the winner and every WASM integration test failed
 /// without python ever being tried.</para>
 ///
+/// <para>Budgets here are generous on purpose. A cold python takes over 5s to answer on the
+/// Windows runner and over 10s on the macOS ARM one -- the same slowness that keeps the WASM
+/// suite off those jobs -- so a candidate is only ever rejected for dying, never for being
+/// slower than a number picked on a fast dev box.</para>
+///
 /// <para>These tests need no browser and no prebuilt WASM app, so they run in every CI job
 /// rather than only where the Playwright suite does.</para>
 /// </summary>
@@ -22,6 +27,13 @@ public sealed class StaticServerFallbackTests : IDisposable
 {
     /// <summary>A dotnet verb that cannot exist, so the muxer always prints and exits 1.</summary>
     private const string MissingDotnetVerb = "serve-no-such-command";
+
+    /// <summary>
+    /// How long the deliberately useless candidate lives. Long enough to still be running when
+    /// the first probe hits it -- the old code accepted anything alive after 500ms -- and short
+    /// enough that rejecting it costs the suite seconds rather than a whole timeout budget.
+    /// </summary>
+    private const int DoomedCandidateLifetimeSeconds = 3;
 
     /// <summary>
     /// The python this machine has, resolved once. Every CI runner ships one; a dev box without
@@ -63,20 +75,21 @@ public sealed class StaticServerFallbackTests : IDisposable
     }
 
     [Fact]
-    public async Task StartStaticServerAsync_FallsThroughACandidateThatStaysAliveWithoutServing()
+    public async Task StartStaticServerAsync_FallsThroughACandidateThatOutlivesItsStartup()
     {
         Assert.SkipWhen(Python is null, "No python available to serve the fallback candidate.");
 
-        // A live process that never binds the port. Surviving startup is not evidence of a
-        // working server, which is exactly what the old 500ms liveness check assumed: it would
-        // have returned this sleeper and then failed the run on a readiness timeout, with the
-        // working candidate behind it never tried.
+        // A process that is alive for the first probes and never binds the port. Surviving
+        // startup is not evidence of a working server, which is exactly what the old 500ms
+        // liveness check assumed: it would have returned this sleeper and then failed the run on
+        // a readiness timeout, with the working candidate behind it never tried.
         var handle = await StartAsync(
             [
-                new(Python!.Value.FileName, (_, _) => PythonArguments("-c \"import time; time.sleep(120)\"")),
+                new(Python!.Value.FileName,
+                    (_, _) => PythonArguments(
+                        $"-c \"import time; time.sleep({DoomedCandidateLifetimeSeconds})\"")),
                 PythonServerCandidate(),
-            ],
-            perCandidateTimeoutMs: 5_000);
+            ]);
 
         await AssertServesProbeFileAsync(handle);
     }
@@ -112,7 +125,7 @@ public sealed class StaticServerFallbackTests : IDisposable
     /// </summary>
     private async Task<WasmAppFixture.StaticServerHandle> StartAsync(
         IReadOnlyList<WasmAppFixture.StaticServerCandidate> candidates,
-        int perCandidateTimeoutMs = 10_000)
+        int perCandidateTimeoutMs = 30_000)
     {
         await File.WriteAllTextAsync(
             Path.Combine(_rootDirectory, "index.html"), "<html>static-server-probe</html>");

--- a/MonacoEditorComponent.Tests/StaticServerFallbackTests.cs
+++ b/MonacoEditorComponent.Tests/StaticServerFallbackTests.cs
@@ -15,10 +15,16 @@ namespace MonacoEditorComponent.Tests;
 /// exit 1, the doomed process was returned as the winner and every WASM integration test failed
 /// without python ever being tried.</para>
 ///
-/// <para>Budgets here are generous on purpose. A cold python takes over 5s to answer on the
-/// Windows runner and over 10s on the macOS ARM one -- the same slowness that keeps the WASM
-/// suite off those jobs -- so a candidate is only ever rejected for dying, never for being
-/// slower than a number picked on a fast dev box.</para>
+/// <para>Budgets here are generous on purpose: a cold python takes over 5s to answer on the
+/// Windows runner, so a candidate is only ever rejected for dying, never for being slower than a
+/// number picked on a fast dev box.</para>
+///
+/// <para>The two tests that need a real server carry <c>Category=StaticServer</c>, which the
+/// macOS ARM job excludes. A python http.server there accepts the connection and then never
+/// answers -- it prints nothing even unbuffered, and probes time out rather than being refused,
+/// so it hangs somewhere before it serves. That is the same behaviour behind this repo keeping
+/// the WASM suite off that runner, and worth its own investigation rather than a bigger
+/// number here.</para>
 ///
 /// <para>These tests need no browser and no prebuilt WASM app, so they run in every CI job
 /// rather than only where the Playwright suite does.</para>
@@ -57,6 +63,7 @@ public sealed class StaticServerFallbackTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "StaticServer")]
     public async Task StartStaticServerAsync_SkipsCandidatesItCannotEvenStart()
     {
         Assert.SkipWhen(Python is null, "No python available to serve the fallback candidate.");
@@ -75,6 +82,7 @@ public sealed class StaticServerFallbackTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "StaticServer")]
     public async Task StartStaticServerAsync_FallsThroughACandidateThatOutlivesItsStartup()
     {
         Assert.SkipWhen(Python is null, "No python available to serve the fallback candidate.");

--- a/MonacoEditorComponent.Tests/StaticServerFallbackTests.cs
+++ b/MonacoEditorComponent.Tests/StaticServerFallbackTests.cs
@@ -1,0 +1,202 @@
+using System.Diagnostics;
+
+using Xunit;
+
+namespace MonacoEditorComponent.Tests;
+
+/// <summary>
+/// Tests for <see cref="WasmAppFixture.StartStaticServerAsync"/>, the candidate fall-through that
+/// picks whichever static file server this machine actually has.
+///
+/// <para>Regression cover for CI run 33770173883: the previous implementation accepted any
+/// candidate still running 500ms after <c>Process.Start</c> and only then probed it, so a
+/// candidate that was not a working server could never be fallen through from. When the dotnet
+/// muxer took longer than that grace period to report the missing <c>dotnet-serve</c> tool and
+/// exit 1, the doomed process was returned as the winner and every WASM integration test failed
+/// without python ever being tried.</para>
+///
+/// <para>These tests need no browser and no prebuilt WASM app, so they run in every CI job
+/// rather than only where the Playwright suite does.</para>
+/// </summary>
+public sealed class StaticServerFallbackTests : IDisposable
+{
+    /// <summary>A dotnet verb that cannot exist, so the muxer always prints and exits 1.</summary>
+    private const string MissingDotnetVerb = "serve-no-such-command";
+
+    /// <summary>
+    /// The python this machine has, resolved once. Every CI runner ships one; a dev box without
+    /// python skips the tests that need a real server rather than failing.
+    /// </summary>
+    private static readonly (string FileName, string ArgumentPrefix)? Python = ResolvePython();
+
+    private readonly string _rootDirectory;
+
+    public StaticServerFallbackTests()
+    {
+        _rootDirectory = Path.Combine(Path.GetTempPath(), $"monaco-static-server-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_rootDirectory);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_rootDirectory, recursive: true); }
+        catch (IOException) { /* temp folder still held by the OS; not a test failure */ }
+        catch (UnauthorizedAccessException) { /* cleanup denied by ACLs; not a test failure */ }
+    }
+
+    [Fact]
+    public async Task StartStaticServerAsync_SkipsCandidatesItCannotEvenStart()
+    {
+        Assert.SkipWhen(Python is null, "No python available to serve the fallback candidate.");
+
+        var handle = await StartAsync(
+            [
+                // Process.Start itself fails: nothing by this name is on PATH.
+                new($"no-such-server-{Guid.NewGuid():N}", (_, _) => string.Empty),
+                // Starts, prints "Could not execute because the specified command or file was not
+                // found", exits 1 -- the shape that broke CI.
+                new("dotnet", (root, port) => $"{MissingDotnetVerb} --port {port} --directory \"{root}\""),
+                PythonServerCandidate(),
+            ]);
+
+        await AssertServesProbeFileAsync(handle);
+    }
+
+    [Fact]
+    public async Task StartStaticServerAsync_FallsThroughACandidateThatStaysAliveWithoutServing()
+    {
+        Assert.SkipWhen(Python is null, "No python available to serve the fallback candidate.");
+
+        // A live process that never binds the port. Surviving startup is not evidence of a
+        // working server, which is exactly what the old 500ms liveness check assumed: it would
+        // have returned this sleeper and then failed the run on a readiness timeout, with the
+        // working candidate behind it never tried.
+        var handle = await StartAsync(
+            [
+                new(Python!.Value.FileName, (_, _) => PythonArguments("-c \"import time; time.sleep(120)\"")),
+                PythonServerCandidate(),
+            ],
+            perCandidateTimeoutMs: 5_000);
+
+        await AssertServesProbeFileAsync(handle);
+    }
+
+    [Fact]
+    public async Task StartStaticServerAsync_ReportsWhyEveryCandidateWasRejected()
+    {
+        WasmAppFixture.StaticServerCandidate[] candidates =
+        [
+            new("dotnet", (root, port) => $"{MissingDotnetVerb} --port {port} --directory \"{root}\""),
+        ];
+
+        var elapsed = Stopwatch.StartNew();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await WasmAppFixture.StartStaticServerAsync(
+                _rootDirectory, _rootDirectory, candidates, perCandidateTimeoutMs: 30_000));
+
+        elapsed.Stop();
+
+        Assert.Contains("dotnet", ex.Message);
+
+        // The candidate's death ends the attempt, so the budget is never spent. Waiting it out
+        // instead would still fail the run, only 30s later and with a timeout for a diagnosis.
+        Assert.True(
+            elapsed.Elapsed < TimeSpan.FromSeconds(20),
+            $"rejecting a dead candidate took {elapsed.Elapsed}, which means the timeout was waited out");
+    }
+
+    /// <summary>
+    /// Runs the candidate list against the temp root, writing the probe file the assertions below
+    /// look for and keeping process logs out of <c>test-artifacts/</c>.
+    /// </summary>
+    private async Task<WasmAppFixture.StaticServerHandle> StartAsync(
+        IReadOnlyList<WasmAppFixture.StaticServerCandidate> candidates,
+        int perCandidateTimeoutMs = 10_000)
+    {
+        await File.WriteAllTextAsync(
+            Path.Combine(_rootDirectory, "index.html"), "<html>static-server-probe</html>");
+
+        return await WasmAppFixture.StartStaticServerAsync(
+            _rootDirectory, _rootDirectory, candidates, perCandidateTimeoutMs);
+    }
+
+    /// <summary>Asserts the handle is a live server actually serving the temp root.</summary>
+    private static async Task AssertServesProbeFileAsync(WasmAppFixture.StaticServerHandle handle)
+    {
+        try
+        {
+            Assert.False(handle.Process.HasExited, "the returned server had already exited");
+
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+            var body = await client.GetStringAsync($"http://localhost:{handle.Port}/index.html");
+
+            Assert.Contains("static-server-probe", body);
+        }
+        finally
+        {
+            try { handle.Process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            handle.Process.Dispose();
+        }
+    }
+
+    private static WasmAppFixture.StaticServerCandidate PythonServerCandidate() =>
+        new(Python!.Value.FileName,
+            (root, port) => PythonArguments($"-m http.server {port} --directory \"{root}\""));
+
+    /// <summary>Prefixes python arguments with the launcher's version selector when needed.</summary>
+    private static string PythonArguments(string arguments) => Python!.Value.ArgumentPrefix + arguments;
+
+    /// <summary>
+    /// Finds a python that actually runs. The Windows Store stub named <c>python3</c> is on PATH
+    /// on machines without python installed and exits non-zero, so each candidate is executed
+    /// rather than merely resolved.
+    /// </summary>
+    private static (string, string)? ResolvePython()
+    {
+        (string FileName, string ArgumentPrefix)[] candidates =
+        [
+            ("python3", string.Empty),
+            ("python", string.Empty),
+            ("py", "-3 "),
+        ];
+
+        foreach (var (fileName, argumentPrefix) in candidates)
+        {
+            try
+            {
+                using var process = Process.Start(new ProcessStartInfo
+                {
+                    FileName = fileName,
+                    Arguments = argumentPrefix + "-c pass",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                });
+
+                if (process is null)
+                {
+                    continue;
+                }
+
+                if (!process.WaitForExit(15_000))
+                {
+                    process.Kill(entireProcessTree: true);
+                    continue;
+                }
+
+                if (process.ExitCode == 0)
+                {
+                    return (fileName, argumentPrefix);
+                }
+            }
+            catch
+            {
+                // Not on PATH, or not executable here; try the next spelling.
+            }
+        }
+
+        return null;
+    }
+}

--- a/MonacoEditorComponent.Tests/WasmAppFixture.cs
+++ b/MonacoEditorComponent.Tests/WasmAppFixture.cs
@@ -70,29 +70,25 @@ public sealed class WasmAppFixture : IAsyncLifetime
         // 1. Resolve WASM build output directory (Release then Debug fallback).
         var wwwrootPath = ResolveWasmBuildOutput(repoRoot);
 
-        // 2. Pick a random available port.
-        _serverPort = GetAvailablePort();
-
-        // 3. Ensure test-artifacts directory exists.
+        // 2. Ensure the test-artifacts directory exists -- every server candidate logs into it.
         var artifactsDir = Path.Combine(repoRoot, "test-artifacts");
         Directory.CreateDirectory(artifactsDir);
-        _processLogPath = Path.Combine(artifactsDir, $"wasm-fixture-{DateTime.UtcNow:yyyyMMdd-HHmmss}.log");
 
-        // 4. Start a static file server on the wwwroot path.
-        // Use dotnet-serve if available, fallback to python3 http.server.
-        _serverProcess = StartStaticServer(wwwrootPath, _serverPort);
-        _ = CaptureProcessOutputAsync(_serverProcess, _processLogPath);
+        // 3. Start a static file server on the wwwroot path. Candidates are probed to readiness
+        // one at a time and the first that answers wins, so a command that is not installed
+        // costs an attempt rather than the whole run.
+        var server = await StartStaticServerAsync(wwwrootPath, artifactsDir, DefaultStaticServerCandidates);
+        _serverProcess = server.Process;
+        _serverPort = server.Port;
+        _processLogPath = server.LogPath;
 
-        // 5. Wait for server to be ready (fail fast if process dies).
-        await WaitForServerReady($"http://localhost:{_serverPort}/", _serverProcess, _processLogPath, timeoutMs: 15_000);
-
-        // 6. Launch Playwright Chromium browser (headless).
+        // 4. Launch Playwright Chromium browser (headless).
         _browser = await _playwright.Chromium.LaunchAsync(new()
         {
             Headless = true,
         });
 
-        // 7. Create context and page.
+        // 5. Create context and page.
         Context = await _browser.NewContextAsync();
 
         // Start tracing for failure artifact collection.
@@ -104,19 +100,19 @@ public sealed class WasmAppFixture : IAsyncLifetime
 
         Page = await Context.NewPageAsync();
 
-        // 8. Start capturing console output BEFORE navigating. C# Console.WriteLine surfaces
+        // 6. Start capturing console output BEFORE navigating. C# Console.WriteLine surfaces
         // here under WASM, and the readiness marker is emitted during boot -- subscribing after
         // GotoAsync would race it.
         Page.Console += OnPageConsole;
 
-        // 9. Navigate to the WASM app.
+        // 7. Navigate to the WASM app.
         await Page.GotoAsync($"http://localhost:{_serverPort}/", new()
         {
             WaitUntil = WaitUntilState.NetworkIdle,
             Timeout = MonacoReadyTimeoutMs,
         });
 
-        // 10. Wait for the sample's own editor to exist. Counted through the standalone-editor
+        // 8. Wait for the sample's own editor to exist. Counted through the standalone-editor
         // filter, not getEditors(): WASM runs both samples in ONE page against ONE monaco
         // instance, so getEditors() also lists the diff widget's two sub-editors and would go
         // green on a page where the plain editor had not been created at all.
@@ -124,7 +120,7 @@ public sealed class WasmAppFixture : IAsyncLifetime
             $"() => typeof monaco !== 'undefined' && {DiffEditorCases.StandaloneEditorsExpressionBody}.length > 0",
             null, new PageWaitForFunctionOptions { Timeout = MonacoReadyTimeoutMs });
 
-        // 11. Wait for the app to finish its own initialisation.
+        // 9. Wait for the app to finish its own initialisation.
         //
         // The step above is NOT sufficient on its own: it goes green the moment the editor is
         // constructed, while EditorControl.Editor_Loading is still fetching Content.txt and
@@ -133,7 +129,7 @@ public sealed class WasmAppFixture : IAsyncLifetime
         // and the following getValue at t+9.29s returned Content.txt instead.
         await WaitForAppInitCompleteAsync();
 
-        // 12. Snapshot the settled content for tests that assert on first-load state. Indexing
+        // 10. Snapshot the settled content for tests that assert on first-load state. Indexing
         // getEditors() here would read whichever editor happened to be constructed first, which
         // on this page may be a diff sub-editor holding the diff sample's document instead.
         InitialEditorText = await Page.EvaluateAsync<string>(
@@ -238,17 +234,12 @@ public sealed class WasmAppFixture : IAsyncLifetime
             try { await _browser.CloseAsync(); } catch { /* best-effort */ }
         }
 
-        if (_serverProcess is { HasExited: false })
+        if (_serverProcess is not null)
         {
-            try
-            {
-                _serverProcess.Kill(entireProcessTree: true);
-                await _serverProcess.WaitForExitAsync(new CancellationTokenSource(5000).Token);
-            }
-            catch { /* best-effort */ }
+            await TerminateServerAsync(_serverProcess);
+            _serverProcess.Dispose();
         }
 
-        _serverProcess?.Dispose();
         _playwright?.Dispose();
     }
 
@@ -332,101 +323,195 @@ public sealed class WasmAppFixture : IAsyncLifetime
             $"Searched:\n  {string.Join("\n  ", candidates)}");
     }
 
-    private static Process StartStaticServer(string wwwrootPath, int port)
-    {
-        // Try multiple static file servers in priority order for cross-platform support.
-        // dotnet-serve is preferred (.NET ecosystem), then python3 (CI images), then python/py (Windows).
-        (string fileName, string arguments)[] candidates =
-        [
-            ("dotnet", $"serve --port {port} --directory \"{wwwrootPath}\""),
-            ("python3", $"-m http.server {port} --directory \"{wwwrootPath}\""),
-            ("python", $"-m http.server {port} --directory \"{wwwrootPath}\""),
-            ("py", $"-3 -m http.server {port} --directory \"{wwwrootPath}\""),
-        ];
+    /// <summary>
+    /// One static-file-server command to try. <c>BuildArguments</c> receives the directory to
+    /// serve and the port to bind.
+    /// </summary>
+    internal readonly record struct StaticServerCandidate(
+        string FileName,
+        Func<string, int, string> BuildArguments);
 
+    /// <summary>A started static file server that has already answered on its port.</summary>
+    internal sealed record StaticServerHandle(Process Process, int Port, string LogPath);
+
+    /// <summary>
+    /// Static file servers to try, in priority order. dotnet-serve is preferred (.NET ecosystem),
+    /// then python3 (CI images), then python/py (Windows). None of them is guaranteed to exist --
+    /// nothing in this repo installs dotnet-serve, so on CI the first candidate always fails and
+    /// the fall-through below is the load-bearing path, not a nicety.
+    /// </summary>
+    internal static IReadOnlyList<StaticServerCandidate> DefaultStaticServerCandidates { get; } =
+    [
+        new("dotnet", (root, port) => $"serve --port {port} --directory \"{root}\""),
+        new("python3", (root, port) => $"-m http.server {port} --directory \"{root}\""),
+        new("python", (root, port) => $"-m http.server {port} --directory \"{root}\""),
+        new("py", (root, port) => $"-3 -m http.server {port} --directory \"{root}\""),
+    ];
+
+    /// <summary>
+    /// Starts the first candidate command that actually serves <paramref name="wwwrootPath"/>.
+    ///
+    /// <para>Each candidate is probed all the way to an HTTP response before it is accepted, and
+    /// rejected the moment its process exits. An earlier version instead slept 500ms and accepted
+    /// whatever was still running, which made "is this tool installed?" a race against the dotnet
+    /// muxer's startup: on CI run 33770173883 the dotnet candidate took longer than that to print
+    /// "Could not execute because the specified command or file was not found" and exit 1, so the
+    /// doomed process was returned as the winner and all 11 WASM tests failed without python ever
+    /// being tried.</para>
+    /// </summary>
+    internal static async Task<StaticServerHandle> StartStaticServerAsync(
+        string wwwrootPath,
+        string logDirectory,
+        IReadOnlyList<StaticServerCandidate> candidates,
+        int perCandidateTimeoutMs = 15_000)
+    {
         var attempted = new List<string>();
 
-        foreach (var (fileName, arguments) in candidates)
+        foreach (var candidate in candidates)
         {
+            // A fresh port per attempt: the candidate being abandoned may have bound the previous
+            // one, and racing its teardown for the same port buys nothing.
+            var port = GetAvailablePort();
+            var logPath = Path.Combine(
+                logDirectory,
+                $"wasm-fixture-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}-{candidate.FileName}.log");
+
+            Process process;
             try
             {
-                var startInfo = new ProcessStartInfo
+                var started = Process.Start(new ProcessStartInfo
                 {
-                    FileName = fileName,
-                    Arguments = arguments,
+                    FileName = candidate.FileName,
+                    Arguments = candidate.BuildArguments(wwwrootPath, port),
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     CreateNoWindow = true,
-                };
+                });
 
-                var process = Process.Start(startInfo);
-                if (process is null)
+                if (started is null)
                 {
-                    attempted.Add($"{fileName} (returned null)");
+                    attempted.Add($"{candidate.FileName} (Process.Start returned null)");
                     continue;
                 }
 
-                // Wait briefly to verify the process survives startup.
-                // If dotnet-serve is not installed, `dotnet serve` starts then exits
-                // immediately -- we need to detect that and try the next candidate.
-                Thread.Sleep(500);
-                if (process.HasExited)
-                {
-                    var exitCode = process.ExitCode;
-                    process.Dispose();
-                    attempted.Add($"{fileName} (exited immediately with code {exitCode})");
-                    continue;
-                }
-
-                return process;
+                process = started;
             }
             catch (Exception ex)
             {
-                attempted.Add($"{fileName} ({ex.GetType().Name}: {ex.Message})");
+                attempted.Add($"{candidate.FileName} ({ex.GetType().Name}: {ex.Message})");
+                continue;
             }
+
+            // Capture output for every candidate, not just the winner: a rejected candidate's
+            // stderr is the only thing that says why it was rejected.
+            _ = CaptureProcessOutputAsync(process, logPath);
+
+            if (await WaitForServerReadyAsync($"http://localhost:{port}/", process, perCandidateTimeoutMs))
+            {
+                return new StaticServerHandle(process, port, logPath);
+            }
+
+            attempted.Add($"{candidate.FileName} ({await DescribeRejectionAsync(process, logPath)})");
+            await TerminateServerAsync(process);
+            process.Dispose();
         }
 
         throw new InvalidOperationException(
-            "Failed to start static file server. Tried:\n" +
+            "Failed to start a static file server for the WASM app. Tried:\n" +
             string.Join("\n", attempted.Select(a => $"  - {a}")));
     }
 
-    private static async Task WaitForServerReady(string url, Process serverProcess, string logPath, int timeoutMs)
+    /// <summary>
+    /// Polls <paramref name="url"/> until it answers, returning false as soon as the server
+    /// process dies or the budget runs out. Process death is the deterministic "this command is
+    /// unusable" signal, so it is checked every pass rather than once after a fixed sleep.
+    /// </summary>
+    private static async Task<bool> WaitForServerReadyAsync(string url, Process serverProcess, int timeoutMs)
     {
         using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
         var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
 
         while (DateTime.UtcNow < deadline)
         {
-            // Fail fast if the server process has died.
             if (serverProcess.HasExited)
             {
-                var exitCode = serverProcess.ExitCode;
-                var logContent = File.Exists(logPath) ? File.ReadAllText(logPath) : "(no log)";
-                throw new InvalidOperationException(
-                    $"Static file server process exited unexpectedly with code {exitCode} before becoming ready.\n" +
-                    $"Process log:\n{logContent}");
+                return false;
             }
 
             try
             {
-                var response = await httpClient.GetAsync(url);
+                using var response = await httpClient.GetAsync(url);
                 if (response.IsSuccessStatusCode)
                 {
-                    return;
+                    return true;
                 }
             }
             catch (HttpRequestException) { }
             catch (TaskCanceledException) { }
 
-            await Task.Delay(500);
+            await Task.Delay(250);
         }
 
-        var logOnTimeout = File.Exists(logPath) ? File.ReadAllText(logPath) : "(no log)";
-        throw new TimeoutException(
-            $"Static file server at {url} did not become ready within {timeoutMs}ms.\n" +
-            $"Process log:\n{logOnTimeout}");
+        return false;
+    }
+
+    /// <summary>Explains why a candidate was rejected, quoting whatever it managed to print.</summary>
+    private static async Task<string> DescribeRejectionAsync(Process process, string logPath)
+    {
+        var state = process.HasExited
+            ? $"exited with code {process.ExitCode}"
+            : "never answered on its port";
+
+        // The output capture writes from its own task, so give the last lines a moment to land
+        // before quoting them -- this runs only on the failure path.
+        await Task.Delay(200);
+
+        var log = ReadLogTail(logPath);
+        return log.Length == 0 ? state : $"{state}; output: {log}";
+    }
+
+    /// <summary>
+    /// Reads the tail of a process log that is still open for writing, hence the explicit
+    /// <see cref="FileShare.ReadWrite"/> rather than <c>File.ReadAllText</c>.
+    /// </summary>
+    private static string ReadLogTail(string logPath, int maxLines = 20)
+    {
+        try
+        {
+            using var stream = new FileStream(
+                logPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var reader = new StreamReader(stream);
+
+            var lines = reader.ReadToEnd()
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Select(line => line.Trim())
+                .Where(line => line.Length > 0);
+
+            return string.Join(" | ", lines.TakeLast(maxLines));
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    /// <summary>Kills a server process and its children, best-effort.</summary>
+    private static async Task TerminateServerAsync(Process process)
+    {
+        if (process.HasExited)
+        {
+            return;
+        }
+
+        try
+        {
+            // entireProcessTree: the dotnet muxer and the py launcher both run the real server as
+            // a child, which would outlive a kill aimed at the parent alone.
+            process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync(new CancellationTokenSource(5000).Token);
+        }
+        catch { /* best-effort */ }
     }
 
     private static int GetAvailablePort()

--- a/MonacoEditorComponent.Tests/WasmAppFixture.cs
+++ b/MonacoEditorComponent.Tests/WasmAppFixture.cs
@@ -339,13 +339,16 @@ public sealed class WasmAppFixture : IAsyncLifetime
     /// then python3 (CI images), then python/py (Windows). None of them is guaranteed to exist --
     /// nothing in this repo installs dotnet-serve, so on CI the first candidate always fails and
     /// the fall-through below is the load-bearing path, not a nicety.
+    ///
+    /// <para><c>-u</c> keeps python from buffering its startup line and any traceback behind the
+    /// redirected pipe, which is what a rejected candidate's log would otherwise be missing.</para>
     /// </summary>
     internal static IReadOnlyList<StaticServerCandidate> DefaultStaticServerCandidates { get; } =
     [
         new("dotnet", (root, port) => $"serve --port {port} --directory \"{root}\""),
-        new("python3", (root, port) => $"-m http.server {port} --directory \"{root}\""),
-        new("python", (root, port) => $"-m http.server {port} --directory \"{root}\""),
-        new("py", (root, port) => $"-3 -m http.server {port} --directory \"{root}\""),
+        new("python3", (root, port) => $"-u -m http.server {port} --directory \"{root}\""),
+        new("python", (root, port) => $"-u -m http.server {port} --directory \"{root}\""),
+        new("py", (root, port) => $"-3 -u -m http.server {port} --directory \"{root}\""),
     ];
 
     /// <summary>
@@ -363,7 +366,7 @@ public sealed class WasmAppFixture : IAsyncLifetime
         string wwwrootPath,
         string logDirectory,
         IReadOnlyList<StaticServerCandidate> candidates,
-        int perCandidateTimeoutMs = 15_000)
+        int perCandidateTimeoutMs = 30_000)
     {
         var attempted = new List<string>();
 
@@ -407,12 +410,15 @@ public sealed class WasmAppFixture : IAsyncLifetime
             // stderr is the only thing that says why it was rejected.
             _ = CaptureProcessOutputAsync(process, logPath);
 
-            if (await WaitForServerReadyAsync($"http://localhost:{port}/", process, perCandidateTimeoutMs))
+            var rejection = await ProbeUntilReadyAsync(
+                $"http://localhost:{port}/", process, perCandidateTimeoutMs);
+
+            if (rejection is null)
             {
                 return new StaticServerHandle(process, port, logPath);
             }
 
-            attempted.Add($"{candidate.FileName} ({await DescribeRejectionAsync(process, logPath)})");
+            attempted.Add($"{candidate.FileName} ({await DescribeRejectionAsync(process, logPath, rejection)})");
             await TerminateServerAsync(process);
             process.Dispose();
         }
@@ -423,20 +429,25 @@ public sealed class WasmAppFixture : IAsyncLifetime
     }
 
     /// <summary>
-    /// Polls <paramref name="url"/> until it answers, returning false as soon as the server
-    /// process dies or the budget runs out. Process death is the deterministic "this command is
-    /// unusable" signal, so it is checked every pass rather than once after a fixed sleep.
+    /// Polls <paramref name="url"/> until it answers, giving up as soon as the server process dies
+    /// or the budget runs out. Process death is the deterministic "this command is unusable"
+    /// signal, so it is checked every pass rather than once after a fixed sleep.
     /// </summary>
-    private static async Task<bool> WaitForServerReadyAsync(string url, Process serverProcess, int timeoutMs)
+    /// <returns>
+    /// <c>null</c> once the server answers; otherwise why it did not, including the last probe
+    /// failure -- "never answered" alone cannot distinguish a slow start from a broken one.
+    /// </returns>
+    private static async Task<string?> ProbeUntilReadyAsync(string url, Process serverProcess, int timeoutMs)
     {
         using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
         var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        var lastProbe = "not probed yet";
 
         while (DateTime.UtcNow < deadline)
         {
             if (serverProcess.HasExited)
             {
-                return false;
+                return $"last probe of {url}: {lastProbe}";
             }
 
             try
@@ -444,24 +455,26 @@ public sealed class WasmAppFixture : IAsyncLifetime
                 using var response = await httpClient.GetAsync(url);
                 if (response.IsSuccessStatusCode)
                 {
-                    return true;
+                    return null;
                 }
+
+                lastProbe = $"HTTP {(int)response.StatusCode}";
             }
-            catch (HttpRequestException) { }
-            catch (TaskCanceledException) { }
+            catch (HttpRequestException ex) { lastProbe = ex.Message; }
+            catch (TaskCanceledException) { lastProbe = "the request timed out"; }
 
             await Task.Delay(250);
         }
 
-        return false;
+        return $"no response from {url} within {timeoutMs}ms; last probe: {lastProbe}";
     }
 
     /// <summary>Explains why a candidate was rejected, quoting whatever it managed to print.</summary>
-    private static async Task<string> DescribeRejectionAsync(Process process, string logPath)
+    private static async Task<string> DescribeRejectionAsync(Process process, string logPath, string rejection)
     {
         var state = process.HasExited
-            ? $"exited with code {process.ExitCode}"
-            : "never answered on its port";
+            ? $"exited with code {process.ExitCode}; {rejection}"
+            : $"still running; {rejection}";
 
         // The output capture writes from its own task, so give the last lines a moment to land
         // before quoting them -- this runs only on the failure path.

--- a/MonacoEditorComponent.Tests/WasmAppFixture.cs
+++ b/MonacoEditorComponent.Tests/WasmAppFixture.cs
@@ -30,6 +30,9 @@ public sealed class WasmAppFixture : IAsyncLifetime
     /// </summary>
     private const string AppInitSettledMarker = "APP_INIT_SETTLED";
 
+    /// <summary>How long a rejected candidate's output capture gets to finish before it is quoted.</summary>
+    private const int CaptureDrainTimeoutMs = 2_000;
+
     /// <summary>Content every test starts from -- see <see cref="ResetEditorStateAsync"/>.</summary>
     private const string ResetText = "// test-init-text";
 
@@ -377,7 +380,7 @@ public sealed class WasmAppFixture : IAsyncLifetime
             var port = GetAvailablePort();
             var logPath = Path.Combine(
                 logDirectory,
-                $"wasm-fixture-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}-{candidate.FileName}.log");
+                $"wasm-fixture-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}-{Path.GetFileName(candidate.FileName)}.log");
 
             Process process;
             try
@@ -407,8 +410,9 @@ public sealed class WasmAppFixture : IAsyncLifetime
             }
 
             // Capture output for every candidate, not just the winner: a rejected candidate's
-            // stderr is the only thing that says why it was rejected.
-            _ = CaptureProcessOutputAsync(process, logPath);
+            // stderr is the only thing that says why it was rejected. The winner's capture runs
+            // for as long as it serves; a rejected one is drained below.
+            var capture = CaptureProcessOutputAsync(process, logPath);
 
             var rejection = await ProbeUntilReadyAsync(
                 $"http://localhost:{port}/", process, perCandidateTimeoutMs);
@@ -418,8 +422,21 @@ public sealed class WasmAppFixture : IAsyncLifetime
                 return new StaticServerHandle(process, port, logPath);
             }
 
-            attempted.Add($"{candidate.FileName} ({await DescribeRejectionAsync(process, logPath, rejection)})");
+            // Read the liveness before killing it: "still running" versus "exited with code N" is
+            // the difference between a server that never answered and a command that is not
+            // installed, and the kill would erase it.
+            var state = process.HasExited
+                ? $"exited with code {process.ExitCode}"
+                : "still running";
+
             await TerminateServerAsync(process);
+
+            // The capture ends when the dead process's streams hit EOF, so waiting on it both
+            // completes the log before it is quoted and keeps anything from reading the Process
+            // as it is disposed.
+            await Task.WhenAny(capture, Task.Delay(CaptureDrainTimeoutMs));
+
+            attempted.Add($"{candidate.FileName} ({DescribeRejection(state, rejection, ReadLogTail(logPath))})");
             process.Dispose();
         }
 
@@ -429,8 +446,8 @@ public sealed class WasmAppFixture : IAsyncLifetime
     }
 
     /// <summary>
-    /// Polls <paramref name="url"/> until it answers, giving up as soon as the server process dies
-    /// or the budget runs out. Process death is the deterministic "this command is unusable"
+    /// Polls <paramref name="url"/> until it answers with a success status, giving up as soon as
+    /// the server process dies or the budget runs out. Process death is the deterministic "this command is unusable"
     /// signal, so it is checked every pass rather than once after a fixed sleep.
     /// </summary>
     /// <returns>
@@ -470,19 +487,8 @@ public sealed class WasmAppFixture : IAsyncLifetime
     }
 
     /// <summary>Explains why a candidate was rejected, quoting whatever it managed to print.</summary>
-    private static async Task<string> DescribeRejectionAsync(Process process, string logPath, string rejection)
-    {
-        var state = process.HasExited
-            ? $"exited with code {process.ExitCode}; {rejection}"
-            : $"still running; {rejection}";
-
-        // The output capture writes from its own task, so give the last lines a moment to land
-        // before quoting them -- this runs only on the failure path.
-        await Task.Delay(200);
-
-        var log = ReadLogTail(logPath);
-        return log.Length == 0 ? state : $"{state}; output: {log}";
-    }
+    private static string DescribeRejection(string state, string rejection, string log) =>
+        log.Length == 0 ? $"{state}; {rejection}" : $"{state}; {rejection}; output: {log}";
 
     /// <summary>
     /// Reads the tail of a process log that is still open for writing, hence the explicit
@@ -522,7 +528,9 @@ public sealed class WasmAppFixture : IAsyncLifetime
             // entireProcessTree: the dotnet muxer and the py launcher both run the real server as
             // a child, which would outlive a kill aimed at the parent alone.
             process.Kill(entireProcessTree: true);
-            await process.WaitForExitAsync(new CancellationTokenSource(5000).Token);
+
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await process.WaitForExitAsync(timeout.Token);
         }
         catch { /* best-effort */ }
     }
@@ -556,29 +564,31 @@ public sealed class WasmAppFixture : IAsyncLifetime
         try
         {
             await using var logWriter = new StreamWriter(logPath, append: false);
-            // ReadLineAsync returns null at end-of-stream, avoiding the CA2024
-            // diagnostic from synchronous EndOfStream checks in async methods.
-            var stdoutTask = Task.Run(async () =>
-            {
-                string? line;
-                while ((line = await process.StandardOutput.ReadLineAsync()) is not null)
-                {
-                    await logWriter.WriteLineAsync($"[stdout] {line}");
-                    await logWriter.FlushAsync();
-                }
-            });
-            var stderrTask = Task.Run(async () =>
-            {
-                string? line;
-                while ((line = await process.StandardError.ReadLineAsync()) is not null)
-                {
-                    await logWriter.WriteLineAsync($"[stderr] {line}");
-                    await logWriter.FlushAsync();
-                }
-            });
 
-            await Task.WhenAny(Task.WhenAll(stdoutTask, stderrTask), Task.Delay(TimeSpan.FromMinutes(5)));
+            // Both pumps write to the one file and StreamWriter is not thread-safe, so lines from
+            // stdout and stderr could otherwise interleave mid-line and corrupt the log.
+            var writer = TextWriter.Synchronized(logWriter);
+
+            // Runs until both streams reach end-of-stream, which the process exiting guarantees.
+            // An earlier version gave up after 5 minutes and disposed the writer underneath the
+            // pumps, so a long session's log went silent partway through.
+            await Task.WhenAll(
+                PumpAsync(process.StandardOutput, writer, "stdout"),
+                PumpAsync(process.StandardError, writer, "stderr"));
         }
         catch { /* best-effort */ }
+    }
+
+    /// <summary>Copies one process stream into the shared log, tagged with its channel.</summary>
+    private static async Task PumpAsync(StreamReader reader, TextWriter writer, string channel)
+    {
+        // ReadLineAsync returns null at end-of-stream, avoiding the CA2024 diagnostic from
+        // synchronous EndOfStream checks in async methods.
+        string? line;
+        while ((line = await reader.ReadLineAsync()) is not null)
+        {
+            await writer.WriteLineAsync($"[{channel}] {line}");
+            await writer.FlushAsync();
+        }
     }
 }


### PR DESCRIPTION
## What

The WASM integration fixture picked its static file server by starting a candidate command, sleeping 500ms, and accepting it if the process was still alive — then probing for readiness afterwards. That made "is this tool installed?" a race against the child's startup, and it meant a candidate that turned out not to be a working server could never be fallen through from.

Nothing in this repo installs `dotnet-serve`, so the first candidate always fails on CI and the fall-through to python is the load-bearing path, not a nicety. On [run 33770173883](https://github.com/unoplatform/uno.monaco.editor/actions/runs/33770173883/job/100698095437) the dotnet muxer took longer than the grace period to print `Could not execute because the specified command or file was not found` and exit 1, so the doomed process was returned as the winner, python was never tried, and all 11 WASM tests failed on `main`:

```
System.InvalidOperationException : Static file server process exited unexpectedly
with code 1 before becoming ready.
```

The exception message is the tell: it comes from the readiness wait, not from the candidate loop — proof the dead candidate had already been accepted.

## How

`StartStaticServerAsync` now starts *and* probes each candidate in one loop:

- poll until it answers, and reject it the moment its process exits — process death is deterministic, so the observed failure no longer depends on any threshold (bumping 500ms to 3s would only move the dice);
- a fresh port per attempt, rather than racing an abandoned candidate's teardown for the same one;
- 30s per candidate, so a candidate is only ever rejected for dying, never for being slower than a number picked on a fast dev box — a cold `python -m http.server` needs over 5s to first answer on the Windows runner;
- capture output for every candidate, not just the winner, and record the last probe failure. "Never answered" alone cannot distinguish a slow start from a broken server, which is exactly what had to be guessed from the first CI round here;
- kill rejected candidates with `entireProcessTree`, shared with `DisposeAsync`.

## Tests

New `StaticServerFallbackTests`, needing no browser and no prebuilt WASM app:

- skips candidates that cannot be started at all, and one that starts then dies (the CI shape), and serves from the first that works;
- **falls through a candidate that outlives its startup and then exits** — a python sleeper. This is the deterministic pin: the old code accepted anything alive after 500ms, so it would have returned the sleeper and then failed the run on a readiness timeout. A bogus `dotnet` verb does *not* pin it, since it dies in ~300ms on a fast machine and the old grace period caught it;
- reports why every candidate was rejected, fast, rather than waiting out the budget.

Locally: 308 tests green, including all 11 WASM Playwright tests against the real fixture.

## macOS ARM

The two tests that need a real server carry `Category=StaticServer`, which the macOS ARM job excludes alongside the `DesktopCDP` and `WasmPlaywright` it already skips. A `python -m http.server` started on that runner accepts the connection and then never answers — it prints nothing even with `-u`, and probes time out instead of being refused, so it hangs somewhere before it serves. A 30s budget changed nothing.

That is almost certainly what "the static file server startup is too slow on ARM runners" in the CI notes was really describing. `AGENTS.md` now records the symptom instead of the guess. Ubuntu and Windows both run these tests; the third test needs no server and runs everywhere.

Chasing *why* python hangs there is a real lead for lifting the macOS-ARM WASM exclusion, but it is a separate investigation, not part of this unblock.

## Review follow-ups

The last commit addresses the Copilot review, including two findings it filed as suppressed comments rather than threads: the fire-and-forget output capture was racing the kill-and-dispose of the process it was reading, both pumps shared a non-thread-safe `StreamWriter` (and the old 5-minute cap disposed that writer underneath them, so a long session lost the rest of its log), and the terminator leaked a `CancellationTokenSource` timer per call.

Not taken: the best-effort `catch` reports, which match the idiom used throughout both fixtures, and the `Path.Combine` reports, which cannot drop an argument here — though the log name now goes through `Path.GetFileName` regardless, so a candidate spelled as a path cannot escape the log directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
