### PR TITLE
fix(editor): tokenize documents on assignment

### DIFF
--- a/MonacoEditorComponent.Tests/TokenizationStarvationCases.cs
+++ b/MonacoEditorComponent.Tests/TokenizationStarvationCases.cs
@@ -1,0 +1,240 @@
+namespace MonacoEditorComponent.Tests;
+
+/// <summary>
+/// Page expressions for the re-applied-document tokenization guard.
+///
+/// <para><b>What the defect is.</b> Neither <c>model.setValue</c> nor
+/// <c>monaco.editor.setModelLanguage</c> tokenizes. Both flush the token store and hand the work
+/// to Monaco's <c>DefaultBackgroundTokenizer</c>, which schedules itself through
+/// <c>requestIdleCallback</c>. A host that repaints every animation frame and owns the main
+/// thread -- a focused WebAssembly app -- need never present an idle period, so that callback can
+/// stay pending indefinitely and the document paints with the theme's default token class only.
+/// The model reports the right language and the right content throughout, so every model-level
+/// assertion passes while the page renders as plain text.</para>
+///
+/// <para><b>Why the visible range has to be held still.</b> Monaco has a second, non-idle
+/// tokenization path: an <c>AttachedViewHandler</c> per attached view refreshes the tokens for
+/// the lines it can see, on a 50ms timer rather than on idle. It is gated on the visible line
+/// range having <i>changed</i> since it last ran, which is what makes this look like a
+/// "re-open" bug rather than a tokenization bug -- the first document into a given editor grows
+/// the visible range from one line to a viewport and gets tokenized, and every later document of
+/// a similar shape leaves that range untouched and does not. Scrolling into unseen lines also
+/// repairs itself through that path (with heuristically-guessed start states), which is why only
+/// a same-viewport re-apply exposes the starvation.</para>
+///
+/// <para><b>Why the idle callback is stubbed rather than starved for real.</b> A
+/// CDP/Playwright-driven window is unfocused and therefore throttled, so it always has idle time
+/// and the background tokenizer always runs; occupying the main thread with timers does not
+/// change that, since short bursts still leave gaps the browser uses for idle work. Replacing
+/// <c>requestIdleCallback</c> is what makes the starvation deterministic, and it does take effect
+/// at runtime: Monaco's idle helper picks its implementation once at bundle load, and the branch
+/// it picks when the API exists reads <c>globalThis.requestIdleCallback</c> on every call.</para>
+/// </summary>
+internal static class TokenizationStarvationCases
+{
+    /// <summary>
+    /// The document pushed into the editor, as an argument rather than inline so it needs no
+    /// escaping. C# because the bundled grammar colours its keywords, types and strings
+    /// distinctly; the assertion only needs <i>some</i> class other than the default.
+    /// </summary>
+    public const string Sample = """
+        using System;
+        using System.Collections.Generic;
+
+        namespace Demo
+        {
+            /// <summary>A type with enough syntax to colour.</summary>
+            public sealed class Program
+            {
+                private const int Answer = 42;
+
+                // A line comment, which the grammar gives its own token type.
+                public static void Main(string[] args)
+                {
+                    var greeting = "hello";
+                    var numbers = new List<int> { 1, 2, 3 };
+
+                    foreach (var number in numbers)
+                    {
+                        Console.WriteLine($"{greeting} {number} {Answer}");
+                    }
+                }
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The element the component registered the plain editor against, found through the
+    /// component's own registry.
+    /// </summary>
+    /// <remarks>
+    /// The element is what every helper takes, and it cannot be derived from the editor: the
+    /// host is an ancestor of <c>getDomNode()</c> at no fixed depth. <c>EditorContext._editors</c>
+    /// is keyed by it, and esbuild's minifier renames locals but not member names, so the lookup
+    /// survives the production bundle.
+    /// </remarks>
+    private const string HostElementExpressionBody =
+        "(() => { const editor = " + DiffEditorCases.StandaloneEditorsExpressionBody + "[0];" +
+        " for (const [element, context] of EditorContext._editors) {" +
+        " if (context.editor === editor) { return element; } } return null; })()";
+
+    /// <summary>The distinct <c>mtk</c> token classes painted in the plain editor's host.</summary>
+    /// <remarks>
+    /// Brackets and braces stay coloured even when tokenization never ran, because bracket-pair
+    /// colorization is delivered as decorations in co-classes rather than as token classes -- so
+    /// this reads the <c>mtk</c> class off each span rather than trusting that anything at all is
+    /// coloured.
+    /// </remarks>
+    public const string PaintedTokenClassesExpression =
+        "() => { const host = " + HostElementExpressionBody + "; if (!host) { return ''; }" +
+        " const pattern = new RegExp('mtk[0-9]+');" +
+        " return [...new Set([...host.querySelectorAll('.view-line span[class*=\"mtk\"]')]" +
+        ".map(span => (span.className.match(pattern) || [''])[0]).filter(Boolean))].sort().join(','); }";
+
+    /// <summary>
+    /// Applies the document once, normally. This is the load that works: it grows the visible
+    /// line range from the reset text's single line to a viewport, so Monaco's own attached-view
+    /// refresh tokenizes it. Its purpose is to leave that range equal to what the re-apply below
+    /// will produce -- without it the re-apply would change the range too and be repaired by the
+    /// same path, and the guard would pass whether the fix is present or not.
+    /// </summary>
+    public const string PrimeExpression =
+        "(sample) => { const host = " + HostElementExpressionBody + "; if (!host) { return false; }" +
+        " updateLanguage(host, 'csharp'); updateContent(host, sample); return true; }";
+
+    /// <summary>
+    /// Clears the editor the way a consumer clears a preview and re-applies the same document
+    /// with the idle callback suspended, then reads back what was painted.
+    ///
+    /// <para>Returns, in order: the painted token classes, the model's language id, whether the
+    /// browser really has the idle API this suspends, and the model's line count. The idle-API
+    /// flag is reported rather than assumed: Monaco's idle helper falls back to a
+    /// <c>setTimeout</c> deadline when <c>requestIdleCallback</c> is missing, and that fallback
+    /// is never starved -- so on a browser without the API this whole guard would pass with or
+    /// without the fix, and the test has to say so instead of going quietly green.</para>
+    /// </summary>
+    /// <remarks>
+    /// Stub, act, render and restore all happen inside one evaluation, with the restore in a
+    /// <c>finally</c>. The WASM collection shares a single page, so a throw between the stub and
+    /// the restore would leave every later test in the collection running against a dead idle
+    /// callback -- order-dependent failures with no visible connection to this test. Keeping it
+    /// in one synchronous block also removes any await boundary at which a real idle callback
+    /// could slip in and tokenize the document behind the assertion's back.
+    /// </remarks>
+    public static readonly string StarvedReapplyExpression = """
+        (sample) => {
+            const idleApiPresent = typeof globalThis.requestIdleCallback === 'function'
+                && typeof globalThis.cancelIdleCallback === 'function';
+
+            const editor = HOST_EDITORS[0];
+            const host = HOST_ELEMENT;
+            if (!host) { return ['', '', String(idleApiPresent), '0']; }
+
+            const savedRequestIdleCallback = globalThis.requestIdleCallback;
+            globalThis.requestIdleCallback = function () { return 0; };
+
+            try {
+                // The clear a consuming app does between documents, then the payload, language
+                // first -- the ordering the component's own property pushes produce.
+                updateContent(host, '');
+                updateLanguage(host, 'plaintext');
+                updateLanguage(host, 'csharp');
+                updateContent(host, sample);
+
+                // Synchronous, and deliberately not a repair: a forced render paints whatever
+                // tokens the model holds, so it cannot mask missing ones.
+                editor.render(true);
+
+                const model = editor.getModel();
+                const pattern = new RegExp('mtk[0-9]+');
+                const painted = [...new Set([...host.querySelectorAll('.view-line span[class*="mtk"]')]
+                    .map(span => (span.className.match(pattern) || [''])[0]).filter(Boolean))]
+                    .sort().join(',');
+
+                return [painted, model.getLanguageId(), String(idleApiPresent), String(model.getLineCount())];
+            } finally {
+                globalThis.requestIdleCallback = savedRequestIdleCallback;
+            }
+        }
+        """
+        .Replace("HOST_EDITORS", DiffEditorCases.StandaloneEditorsExpressionBody, StringComparison.Ordinal)
+        .Replace("HOST_ELEMENT", HostElementExpressionBody, StringComparison.Ordinal);
+
+    /// <summary>
+    /// The element a <c>DiffCodeEditor</c> was registered against.
+    /// </summary>
+    /// <remarks>
+    /// Matched on <c>diffEditor</c> rather than on <c>editor</c>: a diff context aliases
+    /// <c>editor</c> onto the <i>modified</i> sub-editor, so both a plain editor and a diff
+    /// editor answer to that field and the plain one would win on a page hosting both.
+    /// </remarks>
+    private const string DiffHostElementExpressionBody =
+        "(() => { const widget = " + DiffEditorCases.StandaloneDiffEditorsExpressionBody + "[0];" +
+        " for (const [element, context] of EditorContext._editors) {" +
+        " if (context.diffEditor === widget) { return element; } } return null; })()";
+
+    /// <summary>
+    /// The distinct <c>mtk</c> token classes painted in the diff widget's original (left) pane.
+    /// </summary>
+    /// <remarks>
+    /// Scoped to that pane's own DOM node. The two panes are separate editors over separate
+    /// models that starve independently, so a query over the whole widget would be satisfied by
+    /// whichever side happened to be tokenized.
+    /// </remarks>
+    public const string OriginalPanePaintedTokenClassesExpression =
+        "() => { const widget = " + DiffEditorCases.StandaloneDiffEditorsExpressionBody + "[0];" +
+        " const node = widget && widget.getOriginalEditor().getDomNode(); if (!node) { return ''; }" +
+        " const pattern = new RegExp('mtk[0-9]+');" +
+        " return [...new Set([...node.querySelectorAll('.view-line span[class*=\"mtk\"]')]" +
+        ".map(span => (span.className.match(pattern) || [''])[0]).filter(Boolean))].sort().join(','); }";
+
+    /// <summary>
+    /// Applies the document to the original side once, normally, for the same reason
+    /// <see cref="PrimeExpression"/> does: to settle that pane's visible line range at what the
+    /// re-apply will produce, so Monaco's attached-view refresh has no change to react to.
+    /// </summary>
+    public const string PrimeOriginalExpression =
+        "(sample) => { const host = " + DiffHostElementExpressionBody + "; if (!host) { return false; }" +
+        " updateOriginalLanguage(host, 'csharp'); updateOriginalContent(host, sample); return true; }";
+
+    /// <summary>
+    /// The original-side counterpart of <see cref="StarvedReapplyExpression"/>, returning the
+    /// same four values read from the original pane.
+    /// </summary>
+    public static readonly string StarvedOriginalReapplyExpression = """
+        (sample) => {
+            const idleApiPresent = typeof globalThis.requestIdleCallback === 'function'
+                && typeof globalThis.cancelIdleCallback === 'function';
+
+            const widget = DIFF_EDITORS[0];
+            const host = DIFF_HOST_ELEMENT;
+            if (!host || !widget) { return ['', '', String(idleApiPresent), '0']; }
+
+            const savedRequestIdleCallback = globalThis.requestIdleCallback;
+            globalThis.requestIdleCallback = function () { return 0; };
+
+            try {
+                updateOriginalContent(host, '');
+                updateOriginalLanguage(host, 'plaintext');
+                updateOriginalLanguage(host, 'csharp');
+                updateOriginalContent(host, sample);
+
+                const original = widget.getOriginalEditor();
+                original.render(true);
+
+                const model = original.getModel();
+                const node = original.getDomNode();
+                const pattern = new RegExp('mtk[0-9]+');
+                const painted = [...new Set([...node.querySelectorAll('.view-line span[class*="mtk"]')]
+                    .map(span => (span.className.match(pattern) || [''])[0]).filter(Boolean))]
+                    .sort().join(',');
+
+                return [painted, model.getLanguageId(), String(idleApiPresent), String(model.getLineCount())];
+            } finally {
+                globalThis.requestIdleCallback = savedRequestIdleCallback;
+            }
+        }
+        """
+        .Replace("DIFF_EDITORS", DiffEditorCases.StandaloneDiffEditorsExpressionBody, StringComparison.Ordinal)
+        .Replace("DIFF_HOST_ELEMENT", DiffHostElementExpressionBody, StringComparison.Ordinal);
+}

--- a/MonacoEditorComponent.Tests/WasmIntegrationTests.cs
+++ b/MonacoEditorComponent.Tests/WasmIntegrationTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 using Microsoft.Playwright;
 
 using Xunit;
@@ -21,6 +23,7 @@ namespace MonacoEditorComponent.Tests;
 public sealed class WasmIntegrationTests : IAsyncLifetime
 {
     private const int DiffTimeoutMs = 30_000;
+    private const int TokenizationTimeoutMs = 15_000;
 
     private readonly WasmAppFixture _fixture;
     private string _currentTestName = "unknown";
@@ -422,6 +425,131 @@ public sealed class WasmIntegrationTests : IAsyncLifetime
             Assert.True(
                 await _fixture.Page.EvaluateAsync<bool>(MultiDiffEditorCases.ChevronGlyphRenderedExpression),
                 "The collapse chevron must resolve to a codicon glyph.");
+        }
+        catch
+        {
+            _testFailed = true;
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// A document re-applied to an existing editor must be tokenized by the time it is painted,
+    /// even when the host never yields an idle period.
+    ///
+    /// <para><c>updateLanguage</c> + <c>updateContent</c> only queue tokenization, on an idle
+    /// callback that a continuously-rendering WebAssembly host can starve indefinitely. The model
+    /// keeps reporting the right language and the right text, so nothing else here notices, while
+    /// the page paints every span with the theme's default class. See
+    /// <see cref="TokenizationStarvationCases"/> for why the visible range has to be held still
+    /// and why the idle callback is stubbed rather than starved for real.</para>
+    /// </summary>
+    [Fact]
+    [Trait("Category", "WasmPlaywright")]
+    public async Task ReappliedDocument_IsTokenizedWithoutIdleTime()
+    {
+        _currentTestName = nameof(ReappliedDocument_IsTokenizedWithoutIdleTime);
+        try
+        {
+            // Apply the document once, normally, and wait until it is visibly coloured. That
+            // settles the visible line range at the viewport, so the re-apply below leaves it
+            // unchanged -- which is the condition under which Monaco's non-idle attached-view
+            // refresh declines to run and the starvation becomes observable.
+            Assert.True(
+                await _fixture.Page.EvaluateAsync<bool>(
+                    TokenizationStarvationCases.PrimeExpression,
+                    TokenizationStarvationCases.Sample),
+                "The plain editor's host element was not found in EditorContext._editors.");
+
+            await _fixture.Page.WaitForFunctionAsync(
+                $"() => {{ const painted = ({TokenizationStarvationCases.PaintedTokenClassesExpression})();"
+                + " return painted !== '' && painted !== 'mtk1'; }",
+                null, new PageWaitForFunctionOptions { Timeout = TokenizationTimeoutMs });
+
+            var result = await _fixture.Page.EvaluateAsync<string[]>(
+                TokenizationStarvationCases.StarvedReapplyExpression,
+                TokenizationStarvationCases.Sample);
+
+            var painted = result[0];
+            var language = result[1];
+            var idleApiPresent = result[2];
+            var lineCount = result[3];
+
+            // The premise, not padding: with no requestIdleCallback to suspend, Monaco uses a
+            // setTimeout deadline that is never starved, and this test would pass with or
+            // without the fix.
+            // Lower-case: the flag crosses the boundary through JS String(), not ToString().
+            Assert.Equal("true", idleApiPresent);
+
+            // The document really did land -- otherwise "nothing was painted" would be the
+            // trivial explanation for the assertion below.
+            Assert.Equal("csharp", language);
+            Assert.True(
+                int.Parse(lineCount, CultureInfo.InvariantCulture) > 1,
+                $"Expected the sample document in the model, got {lineCount} line(s).");
+
+            // mtk1 is the theme's default foreground. A document that was never tokenized paints
+            // nothing else -- brackets stay coloured through decorations, not token classes, so
+            // "something is coloured" is not enough to distinguish the two states.
+            Assert.False(
+                painted is "" or "mtk1",
+                $"The re-applied document was never tokenized: painted token classes were "
+                + $"'{painted}' (expected at least one class besides mtk1). updateContent and "
+                + "updateLanguage must not leave highlighting waiting on idle time.");
+        }
+        catch
+        {
+            _testFailed = true;
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// The diff widget's original (left) document has to survive the same re-apply. Its model is
+    /// attached to its own sub-editor and starves independently of the modified side, and
+    /// <c>updateOriginalContent</c> / <c>updateOriginalLanguage</c> resolve that sub-editor
+    /// through a different expression than every other helper -- so a fix that only reached the
+    /// modified side, or that read the wrong pane's viewport, would look correct here without
+    /// this.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "WasmPlaywright")]
+    public async Task ReappliedOriginalDocument_IsTokenizedWithoutIdleTime()
+    {
+        _currentTestName = nameof(ReappliedOriginalDocument_IsTokenizedWithoutIdleTime);
+        try
+        {
+            Assert.True(
+                await _fixture.Page.EvaluateAsync<bool>(
+                    TokenizationStarvationCases.PrimeOriginalExpression,
+                    TokenizationStarvationCases.Sample),
+                "No DiffCodeEditor host element was found in EditorContext._editors.");
+
+            await _fixture.Page.WaitForFunctionAsync(
+                "() => { const painted = ("
+                + TokenizationStarvationCases.OriginalPanePaintedTokenClassesExpression
+                + ")(); return painted !== '' && painted !== 'mtk1'; }",
+                null, new PageWaitForFunctionOptions { Timeout = TokenizationTimeoutMs });
+
+            var result = await _fixture.Page.EvaluateAsync<string[]>(
+                TokenizationStarvationCases.StarvedOriginalReapplyExpression,
+                TokenizationStarvationCases.Sample);
+
+            var painted = result[0];
+            var language = result[1];
+            var idleApiPresent = result[2];
+            var lineCount = result[3];
+
+            Assert.Equal("true", idleApiPresent);
+            Assert.Equal("csharp", language);
+            Assert.True(
+                int.Parse(lineCount, CultureInfo.InvariantCulture) > 1,
+                $"Expected the sample document in the original model, got {lineCount} line(s).");
+
+            Assert.False(
+                painted is "" or "mtk1",
+                $"The re-applied original document was never tokenized: painted token classes in "
+                + $"the left pane were '{painted}' (expected at least one class besides mtk1).");
         }
         catch
         {

--- a/MonacoEditorComponent/ts-helpermethods/otherScriptsToBeOrganized.ts
+++ b/MonacoEditorComponent/ts-helpermethods/otherScriptsToBeOrganized.ts
@@ -1,6 +1,7 @@
 import * as monaco from 'monaco-editor';
 import { ParentAccessor } from './Monaco.Helpers.ParentAccessor';
 import { callParentEventAsync } from './asyncCallbackHelpers';
+import { tokenizeVisibleRange } from './tokenization';
 
 export class EditorContext {
     static _editors: Map<any, EditorContext> = new Map<any, EditorContext>();
@@ -209,6 +210,12 @@ export const updateContent = function (element: any, content: string) {
     if (content !== editorContext.model.getValue()) {
         editorContext.model.setValue(content);
     }
+
+    // Unconditional, including when the content was already in place: a language push that
+    // arrived just before this one has flushed the token store either way, and a pass over
+    // already-tokenized lines costs a comparison. See tokenization.ts for why the queued
+    // background pass cannot be relied on to do this.
+    tokenizeVisibleRange(editorContext.model, editorContext.editor);
 };
 
 export const updateDecorations = function (element: any, newHighlights: any) {
@@ -265,6 +272,11 @@ export const updateLanguage = function (element: any, language: string) {
     var editorContext = EditorContext.getEditorForElement(element);
 
     monaco.editor.setModelLanguage(editorContext.model, language);
+
+    // setModelLanguage flushes the token store and queues the re-tokenization on an idle
+    // callback a continuously rendering host may never yield -- so the document would keep
+    // reporting the new language while painting as plain text. See tokenization.ts.
+    tokenizeVisibleRange(editorContext.model, editorContext.editor);
 };
 
 export const changeTheme = function (element: any, theme: string, highcontrast: string) {
@@ -381,6 +393,10 @@ export const updateOriginalContent = function (element: any, content: string) {
     if (model && content !== model.getValue()) {
         model.setValue(content);
     }
+
+    // The original side has its own model attached to its own sub-editor, so it starves
+    // independently of the modified side and needs its own pass over its own visible range.
+    tokenizeVisibleRange(model, editorContext?.diffEditor?.getOriginalEditor());
 };
 
 /** Set the syntax language of the original (left-hand) document. */
@@ -390,6 +406,8 @@ export const updateOriginalLanguage = function (element: any, language: string) 
     if (editorContext?.originalModel) {
         monaco.editor.setModelLanguage(editorContext.originalModel, language);
     }
+
+    tokenizeVisibleRange(editorContext?.originalModel, editorContext?.diffEditor?.getOriginalEditor());
 };
 
 /**

--- a/MonacoEditorComponent/ts-helpermethods/tokenization.ts
+++ b/MonacoEditorComponent/ts-helpermethods/tokenization.ts
@@ -1,0 +1,103 @@
+import * as monaco from 'monaco-editor';
+
+/**
+ * Keeping an assigned document tokenized on a host that never goes idle.
+ *
+ * Neither `model.setValue` nor `monaco.editor.setModelLanguage` tokenizes. Both flush the
+ * token store and hand the work to Monaco's `DefaultBackgroundTokenizer`, which schedules
+ * itself through `requestIdleCallback`. A host that repaints every animation frame and owns
+ * the main thread -- a focused WebAssembly app -- need never present an idle period, so that
+ * callback can stay pending indefinitely: the document keeps reporting the right language and
+ * the right content while every span paints with the theme's default token class.
+ *
+ * Monaco does have a second, non-idle path -- an `AttachedViewHandler` per attached view
+ * refreshes the tokens for the lines it can see on a 50ms timer -- but it is gated on the
+ * visible line range having *changed* since it last ran. That is what makes this look like a
+ * "re-open" bug rather than a tokenization bug: the first document into a given editor grows
+ * the visible range from one line to a viewport and gets tokenized, while every later document
+ * of a similar shape leaves that range untouched and does not. Scrolling into unseen lines
+ * goes through the same path and repairs itself, so this only has to cover the assignment.
+ *
+ * `monaco.editor.create()` already tokenizes what it can see, which is the other half of why
+ * first loads look fine. Doing the same after an assignment is what this module is for.
+ */
+
+/**
+ * Lines tokenized past the last visible one, so a small scroll or a line-height change does
+ * not immediately expose untokenized text.
+ */
+const LookAheadLines = 20;
+
+/**
+ * Floor applied when the editor reports no visible range -- a host that has not been laid out
+ * yet -- and headroom for a container that grows after the document was assigned. A height
+ * change alone does *not* trigger Monaco's attached-view refresh, so a host that arrives at
+ * 300px and expands to fill a window would otherwise show untokenized lines in the space it
+ * gained. Measured against this bundle's defaults a viewport line is ~19px, so 100 lines is
+ * headroom for roughly a full-screen editor -- proportionally less if a consumer raises
+ * fontSize or lineHeight, which is why this is headroom and not a guarantee.
+ */
+const MinimumLines = 100;
+
+/**
+ * Ceiling on one synchronous pass. `forceTokenization` runs on the single WebAssembly UI
+ * thread, and a collapsed or unlaid-out host can report a visible range spanning hundreds of
+ * lines, so the viewport is not a bound that can be trusted on its own. Lines past this stay
+ * with the background tokenizer, and with the attached-view refresh that scrolling drives.
+ */
+const MaximumLines = 2000;
+
+/**
+ * The model's tokenization part. Absent from `monaco.d.ts` -- it is public at runtime but not
+ * in the published typings -- so it is described here rather than cast blindly, and every call
+ * site below checks for it instead of assuming a given Monaco version exposes it.
+ */
+interface TokenizationPart {
+    forceTokenization(lineNumber: number): void;
+}
+
+/**
+ * Tokenize the lines `editor` can currently see, synchronously.
+ *
+ * Call after assigning content or a language to a model that is already attached to an editor.
+ * Cheap when the lines are already tokenized: `forceTokenization` stops at the first valid
+ * line, and a pass that computes nothing fires no token-change event.
+ *
+ * @param model The model that was just assigned to. Ignored when absent or disposed.
+ * @param editor The editor showing it, used only for its visible range. When it is absent, has
+ * no layout yet, or reports nothing, {@link MinimumLines} is tokenized instead.
+ */
+export const tokenizeVisibleRange = function (
+    model: monaco.editor.ITextModel | undefined,
+    editor: monaco.editor.ICodeEditor | undefined
+): void {
+    if (!model || model.isDisposed()) {
+        return;
+    }
+
+    const tokenization = (model as any).tokenization as TokenizationPart | undefined;
+    if (!tokenization || typeof tokenization.forceTokenization !== 'function') {
+        return;
+    }
+
+    let through = MinimumLines;
+
+    try {
+        const ranges = editor ? editor.getVisibleRanges() : [];
+        if (ranges.length) {
+            through = Math.max(through, ranges[ranges.length - 1].endLineNumber + LookAheadLines);
+        }
+    } catch {
+        // A widget mid-teardown, or one that has never been laid out, throws here rather than
+        // reporting an empty range. The floor is the right answer in that case too.
+    }
+
+    through = Math.max(1, Math.min(through, MaximumLines, model.getLineCount()));
+
+    try {
+        tokenization.forceTokenization(through);
+    } catch (error) {
+        // Highlighting is not worth failing a content or language push over.
+        console.warn('[tokenizeVisibleRange] forceTokenization failed:', error);
+    }
+};

--- a/docs/tokenization-idle-starvation.md
+++ b/docs/tokenization-idle-starvation.md
@@ -1,0 +1,277 @@
+# Re-applied documents are never tokenized on a continuously rendering host
+
+A document handed to an existing editor via `updateLanguage` + `updateContent` could stay permanently
+untokenized on a WebAssembly host whose main thread paints every frame. The model reported the correct
+language and the correct content, the grammar was registered, the model was attached — and the view
+painted only the default token class.
+
+The **first** load into a given editor was unaffected, which is what made this look like a
+"re-open" bug in consuming applications rather than a tokenization bug.
+
+**Fixed.** `updateContent`, `updateLanguage`, `updateOriginalContent` and `updateOriginalLanguage` now
+tokenize the visible range themselves — see [The fix](#the-fix). This document is kept because the
+mechanism is subtle, the two tests that guard it will look arbitrary without it, and the same trap is
+waiting in any future helper that assigns to a model.
+
+---
+
+## Symptom
+
+- Painted spans carried only `mtk1` (the theme's default foreground).
+- Brackets and braces were still coloured, because bracket-pair colorization is delivered as
+  decorations (`bracket-highlighting-<n>` co-classes) and is computed independently of the tokenizer.
+- Consequence: a C-family document looked *partially* highlighted — punctuation coloured, keywords and
+  type names flat. An XML/XAML document looked completely flat, because it has no bracket pairs to
+  decorate. The two symptoms have one cause and are easy to mistake for two different bugs.
+- `model.getLanguageId()` returned the right language throughout, so every model-level assertion
+  passed while the page rendered as plain text.
+
+### Measured state
+
+Collected from a focused browser window running a WASM consumer, with the document visibly unhighlighted:
+
+```json
+{
+  "hostCount": 1,
+  "liveHost": "monaco-1027174264",
+  "box": "1383x817",
+  "dpr": 1,
+  "win": "1920x919",
+  "viewLines": 27,
+  "classes": "mtk1",
+  "colours": "rgb(212, 212, 212) rgb(218, 112, 214) rgb(23, 159, 255) rgb(255, 215, 0)",
+  "mtkRules": 24,
+  "lang": "csharp",
+  "len": "628",
+  "theme": "monaco-editor no-user-select  showUnused showDeprecated vs-dark"
+}
+```
+
+`rgb(212,212,212)` is `.mtk1`; the other three are the default bracket-pair colours. `mtkRules: 24`
+shows the theme stylesheet was fully present, so this was not a CSS-delivery problem — the tokens were
+simply never computed.
+
+---
+
+## Cause
+
+It takes **two** mechanisms to produce this, which is why it looked so selective. Monaco has two ways
+to get a line tokenized, and a same-viewport re-apply misses both.
+
+### 1. The background tokenizer is gated on idle time
+
+`setModelLanguage` and `setValue` do not tokenize. They flush the token store and *queue* the
+background tokenizer, which is scheduled on an idle callback. From
+`vs/editor/common/model/textModelTokens.js` (Monaco 0.52.2):
+
+```js
+_beginBackgroundTokenization() {
+    if (this._isScheduled
+        || !this._tokenizerWithStateStore._textModel.isAttachedToEditor()
+        || !this._hasLinesToTokenize()) {
+        return;
+    }
+    this._isScheduled = true;
+    runWhenGlobalIdle((deadline) => {
+        this._isScheduled = false;
+        this._backgroundTokenizeWithDeadline(deadline);
+    });
+}
+```
+
+`runWhenGlobalIdle` resolves to `globalThis.requestIdleCallback` when the API exists. A host that
+repaints its canvas on every animation frame — and owns the main thread while the window is focused —
+need never present an idle period, so the queued callback can remain pending indefinitely. `_isScheduled`
+stays `true`, and the only two places that clear it are the constructor and the callback itself, so
+nothing re-queues either. Until the next flush, that model has no background pass at all.
+
+### 2. The viewport refresh is gated on the visible range *changing*
+
+Monaco's second path is not idle-driven, which is why the bug is not universal.
+`TokenizationTextModelPart` keeps an `AttachedViewHandler` per attached view that refreshes the tokens
+for the lines that view can see, on a 50 ms `RunOnceScheduler` — a plain `setTimeout`, never starved.
+But from `vs/editor/common/model/tokens.js`:
+
+```js
+update() {
+    if (equals(this._computedLineRanges, this._lineRanges, (a, b) => a.equals(b))) {
+        return;
+    }
+    this._computedLineRanges = this._lineRanges;
+    this._refreshTokens();
+}
+```
+
+It runs only when the visible line range differs from the one it last handled. `resetTokenization`
+flushes the token store but leaves `_computedLineRanges` alone, so:
+
+| Situation | Visible range | Outcome |
+|---|---|---|
+| First document into a fresh editor | `1..1` → `1..27` | changed → refreshed → **highlighted** |
+| Same-shaped document re-applied | `1..27` → `1..27` | unchanged → skipped → **flat** |
+| Scrolling into unseen lines | `1..27` → `212..237` | changed → refreshed → **highlighted** |
+| Resizing the host, width or height | irrelevant | the event never fires → **flat** |
+
+That table is the whole bug. Both gates have to close on the same document for it to stay flat, and a
+re-applied payload at an unchanged scroll position is exactly the case that closes both.
+
+### Why the workarounds users found are diagnostic
+
+| Action | Effect | Why |
+|---|---|---|
+| Minimize and restore the window | **Repairs it** | The animation-frame loop stops, the main thread goes idle, the queued callback finally runs |
+| Switch browser tabs and back | **Repairs it** | Same cause |
+| Scroll away and back | **Repairs it** | Changes the visible range, so the attached-view refresh runs — with heuristically guessed start states, so the result can differ from an accurate pass |
+| Resize the window | **No effect** | Fires no visible-range change and creates no idle period |
+
+That resize does *not* help is the useful half: it rules out layout, viewport and sizing, and points
+at the model's token state rather than the view.
+
+---
+
+## Reproduction
+
+Two conditions, both required:
+
+1. **Suspend the idle callback.** A CDP/Playwright-driven window is unfocused and therefore throttled,
+   so it always has idle time and the background tokenizer always runs. Twenty-two open/close/re-open
+   cycles across five driver variants — alternating grammars, dwell times from 0 to 12 s, documents
+   from 31 to 7805 lines, host heights of 320 px and 900 px, and every ordering of hiding/showing the
+   host element — were all clean. Deliberately occupying the main thread with `setInterval` (42 ms of
+   every 50 ms) also failed to reproduce it; short bursts still leave gaps the browser will use for
+   idle work.
+
+   ```js
+   const saved = globalThis.requestIdleCallback;
+   globalThis.requestIdleCallback = function () { return 0; };
+   // … apply the payload and assert, then restore in a finally …
+   ```
+
+   Monaco's idle helper picks its implementation once, in an IIFE at bundle load, and the branch it
+   picks when the API exists reads `globalThis.requestIdleCallback` on every call — so replacing it at
+   runtime does take effect. (When the API is *missing* at bundle load it takes a `setTimeout` branch
+   that is never starved, which is why the tests assert the API is present before trusting a pass.)
+
+2. **Hold the visible line range still.** Apply the document once and let it settle, then re-apply the
+   same document without scrolling. Without this the re-apply changes the range and the attached-view
+   refresh repairs it, and the reproduction goes green whether the fix is present or not.
+
+Then read the painted classes:
+
+```js
+[...new Set([...host.querySelectorAll('.view-line span[class*="mtk"]')]
+  .map(s => (s.className.match(/mtk\d+/) || [''])[0]).filter(Boolean))].sort().join(',')
+```
+
+Expected `mtk1,mtk20,mtk6`-style set; observed `mtk1`.
+
+Both conditions are encoded in `MonacoEditorComponent.Tests/TokenizationStarvationCases.cs`, driving
+`WasmIntegrationTests.ReappliedDocument_IsTokenizedWithoutIdleTime` (plain editor) and
+`ReappliedOriginalDocument_IsTokenizedWithoutIdleTime` (the diff widget's original pane, which starves
+independently). Reverting either half of the fix turns the matching test red on `'mtk1'`.
+
+---
+
+## Diagnostic snippet
+
+Run in the DevTools console while a document is visibly unhighlighted. It reports which repair works,
+which identifies the failure precisely. Note that step 1 triggers a lazy grammar import if one is
+pending, so its result must be read as "was the grammar loaded when I looked".
+
+```js
+(async () => {
+  const H = [...document.querySelectorAll('[id^="monaco-"]')]
+    .filter(e => !e.hidden && e.clientHeight > 0)[0];
+  if (!H) { console.log('no live host'); return; }
+  const cx = globalThis.EditorContext && EditorContext.getEditorForElement(H);
+  const M = cx.model, E = cx.editor;
+  const P = () => [...new Set([...H.querySelectorAll('.view-line span[class*="mtk"]')]
+    .map(s => (s.className.match(/mtk\d+/) || [''])[0]).filter(Boolean))].sort().join(',');
+  const W = ms => new Promise(r => setTimeout(r, ms));
+  const O = ['lang=' + M.getLanguageId() + ' attached=' + M.isAttachedToEditor()];
+  O.push('0. painted now            : ' + P());
+  O.push('1. grammar token types    : ' + [...new Set(monaco.editor
+    .tokenize('public sealed class A { int x = 1; }', M.getLanguageId())
+    .flat().map(t => t.type))].filter(t => t !== '').length);
+  M.tokenization.forceTokenization(Math.min(M.getLineCount(), 40));
+  await W(700); O.push('2. after forceTokenization: ' + P());
+  monaco.editor.setModelLanguage(M, M.getLanguageId());
+  await W(1400); O.push('3. after re-set language  : ' + P());
+  E.render(true);
+  await W(700); O.push('4. after forced render    : ' + P());
+  console.log(O.join('\n'));
+})()
+```
+
+On an affected host: `attached=true`, the grammar reports 8 token types, `0.` is `mtk1`, and `2.`
+repairs it. That combination is the signature — the grammar and the model are both fine and only the
+tokenization pass is missing. `model.tokenization.hasAccurateTokensForLine(n)` is the same answer
+without touching the DOM.
+
+---
+
+## The fix
+
+`ts-helpermethods/tokenization.ts` exports `tokenizeVisibleRange(model, editor)`, called by all four
+helpers that assign to a model: `updateContent`, `updateLanguage`, `updateOriginalContent` and
+`updateOriginalLanguage`. It forces tokenization through the last visible line, which is what
+`monaco.editor.create()` already does for a first load — so an assigned document is highlighted by the
+time it is painted, whatever the host's idle behaviour.
+
+The bounds are the interesting part, since `forceTokenization` is synchronous and runs on the single
+WebAssembly UI thread:
+
+| Bound | Value | Why |
+|---|---|---|
+| Look-ahead | last visible line + 20 | A small scroll or line-height change should not immediately expose flat text |
+| Floor | 100 lines | An editor with no layout yet reports no visible range at all; and a host that arrives small and *grows* gets no attached-view refresh from the resize, so it needs headroom. A viewport line measured ~19 px against this bundle's defaults, so 100 lines is roughly a full-screen editor's worth — proportionally less if a consumer raises `fontSize` or `lineHeight`. It is headroom, not a guarantee |
+| Ceiling | 2000 lines | A collapsed or unlaid-out host can report a visible range spanning hundreds of lines, so the viewport is not a bound that can be trusted on its own |
+
+Repeated calls are cheap: `forceTokenization` stops at the first already-valid line, and a pass that
+computes nothing fires no token-change event. The call is therefore unconditional, including when
+`updateContent` finds the content already in place — a language push that arrived just before it has
+flushed the store either way.
+
+`model.tokenization` is public at runtime but absent from `monaco.d.ts`, so the helper checks for it
+and for `forceTokenization` before calling, and swallows a throw with a warning. A Monaco upgrade that
+moves it degrades to today's behaviour instead of breaking every content push.
+
+### Deliberately not covered
+
+- **Scrolling past the tokenized range.** Monaco's attached-view refresh handles it on a `setTimeout`,
+  not on idle, so it is not starved. Its tokens are heuristic rather than accurate when the viewport
+  is far ahead of the tokenized prefix; adding a synchronous pass on every scroll event would cost the
+  whole prefix on the UI thread to improve on that, which is not a trade worth making here.
+- **`updateMultiDiffFiles`.** The multi-file diff has the same class of exposure, but its per-file
+  editors are pooled and recycled and its render autorun has previously been wedged by well-meaning
+  synchronous work. Left alone on purpose.
+- **Typing into a starved model.** Edits are not flush changes, so they do not re-create the
+  background tokenizer, and `_isScheduled` is still latched. The token store shifts existing tokens
+  across the edit rather than clearing them, so the line degrades gradually rather than going flat.
+
+### Related code paths reviewed while diagnosing
+
+- `CodeEditor/CodeEditor.cs` (~L294) `Options_PropertyChanged` — the language reaches JS from here via
+  `updateLanguage`, and only when `_initialized && _view != null`. On a cold editor the guard skips it
+  and the language instead arrives as a construction option, which is a second reason first loads and
+  later assignments behave differently.
+- `CodeEditor/WasmCodeEditorPresenter.cs` (~L142) `InvokeScriptAsync` returns `Task.FromResult`, so the
+  language/content assignment order is preserved synchronously on WebAssembly. Assignment ordering is
+  *not* a contributing factor here.
+- `CodeEditor/CodeEditor.cs` `DeferredTeardownAsync` — not involved: closing a host that merely
+  collapses its container never raises `Unloaded`, so no teardown runs and subscriptions stay intact.
+
+## Ruled out
+
+Each of these was measured, not reasoned away:
+
+| Hypothesis | Why it is not the cause |
+|---|---|
+| Lazy Monarch grammar import | Real and reproducible (a cold grammar paints `mtk1` for ~7–9 s) but it **self-repairs**, so it cannot persist. Grammars are bundled, so there is no chunk fetch to fail. |
+| Theme stylesheet lost | `mtkRules: 24` present; `.mtk1`/`.mtk5` resolve to correct colours. |
+| More than one editor host | `hostCount: 1`. |
+| Model detached from the editor | `isAttachedToEditor()` returns `true`. |
+| Language applied after content | `InvokeScriptAsync` is synchronous on WebAssembly; ordering is preserved. |
+| Deferred teardown on close | Never fires — the container is collapsed, not unloaded. |
+| Layout / viewport / document size | Resize has no effect in either axis; 31–7805 line documents against 320 px and 900 px hosts are all clean when the window is unfocused. |
+| `backgroundTokenizationState` | Reports `2` (Completed) on an affected model. It latches on the first completed pass and never goes back, so it is not a usable signal. |


### PR DESCRIPTION
## What

A document handed to an **existing** editor via `updateLanguage` + `updateContent` could stay
permanently unhighlighted on a continuously-rendering host. The model reported the right language
and the right content throughout, so every model-level assertion passed while the page painted as
plain text.

Consumers saw this as a "re-open" bug: the first document into a given editor was always fine.

## Why it happened

It takes **two** gates closing on the same document, which is what made it look so selective.

**1. The background tokenizer is idle-gated.** `setValue` and `setModelLanguage` do not tokenize.
They flush the token store and queue Monaco's `DefaultBackgroundTokenizer` through
`requestIdleCallback`. A WebAssembly host that repaints every animation frame and owns the main
thread need never present an idle period, so that callback can stay pending indefinitely.

**2. The viewport refresh is gated on the visible range *changing*.** Monaco's second path is not
idle-driven — an `AttachedViewHandler` per attached view re-tokenizes the lines it can see on a
50 ms `setTimeout`. But it bails when the visible line range equals the one it last handled, and
`resetTokenization` flushes the token store without clearing that record:

| Situation | Visible range | Outcome |
|---|---|---|
| First document into a fresh editor | `1..1` → `1..27` | changed → refreshed → **highlighted** |
| Same-shaped document re-applied | `1..27` → `1..27` | unchanged → skipped → **flat** |
| Scrolling into unseen lines | `1..27` → `212..237` | changed → refreshed → **highlighted** |
| Resizing the host, width or height | irrelevant | the event never fires → **flat** |

Every row was measured, not reasoned about. That table also explains the two observations that
made this hard to place: scrolling repairs it, and resizing does not.

## The fix

New `ts-helpermethods/tokenization.ts` exports `tokenizeVisibleRange(model, editor)`, called by all
four helpers that assign to a model — `updateContent`, `updateLanguage`, `updateOriginalContent`,
`updateOriginalLanguage`. It forces tokenization through the last visible line, which is what
`monaco.editor.create()` already does for a first load.

The bounds are the interesting part, since `forceTokenization` is synchronous on the single
WebAssembly UI thread:

| Bound | Value | Why |
|---|---|---|
| Look-ahead | last visible line + 20 | A small scroll should not immediately expose flat text |
| Floor | 100 lines | An unlaid-out editor reports no visible range; and a host that arrives small and *grows* gets no refresh from the resize, so it needs headroom |
| Ceiling | 2000 lines | A collapsed host measured a **317-line** "visible" range, so the viewport is not a bound that can be trusted on its own |

`model.tokenization` is public at runtime but absent from `monaco.d.ts`, so it is feature-checked
and a throw degrades to a warning — a Monaco upgrade that moves it falls back to today's behaviour
instead of breaking every content push.

### Deliberately not covered

- **Scrolling past the tokenized range** — Monaco's attached-view refresh handles it on a
  `setTimeout`, so it is not starved.
- **`updateMultiDiffFiles`** — same class of exposure, but its render autorun has previously been
  wedged by well-meaning synchronous work. Left alone on purpose.
- **Typing into an already-starved model** — the token store shifts existing tokens across the
  edit, so the line degrades gradually rather than going flat.

## Tests

Two WASM integration tests, one per call-site family. Each needs **both** repro conditions, and
`TokenizationStarvationCases` documents why:

1. `requestIdleCallback` is stubbed. A Playwright-driven window is unfocused and therefore
   throttled, so it always has idle time — the original investigation ran 22 open/close/re-open
   cycles across five driver variants and never reproduced it.
2. The visible line range is held still, by applying the document once before re-applying it.
   Without this the re-apply changes the range and Monaco's own refresh repairs it.

Miss either and the test passes whether the fix is present or not. Both also assert the idle API
was really there to suspend — without it Monaco takes a `setTimeout` branch that is never starved,
and the guard would go quietly green.

Verified red → green with the bundle **and** the WASM app rebuilt in both directions:

| | Observed |
|---|---|
| `ReappliedDocument_IsTokenizedWithoutIdleTime`, before | `painted token classes were 'mtk1'` |
| `ReappliedOriginalDocument_IsTokenizedWithoutIdleTime`, original-side calls removed | red on `'mtk1'` while the modified-side test stayed green |
| Both, after | pass |

Local: **307/307** non-DesktopCDP. Solution and both app targets build clean.

`docs/tokenization-idle-starvation.md` carries the full investigation — the measured symptom,
the repair matrix, a DevTools diagnostic snippet, and a ruled-out table.

## Note on the desktop suite

Local `Category=DesktopCDP` runs are unreliable on this machine in a way that is **not** related to
this change: across five full runs, the whole `DesktopMultiDiffEditorTests` class cascades about
half the time at *any* commit, clean `main` included (0 failed and 14 failed both reproduced at
clean HEAD, same tests, same duration). The class passes 13/13 when run alone and the multi-file
diff path has no `tokenizeVisibleRange` call site. CI is the authority here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
